### PR TITLE
feat: implement all open issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 obj/
 nupkg/
 *.binlog
+tests/*/bin/
+tests/*/obj/

--- a/FsLangMcp.slnx
+++ b/FsLangMcp.slnx
@@ -1,0 +1,6 @@
+<Solution>
+  <Folder Name="/tests/">
+    <Project Path="tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj" />
+  </Folder>
+  <Project Path="FsLangMcp.fsproj" />
+</Solution>

--- a/Program.fs
+++ b/Program.fs
@@ -11,9 +11,12 @@ open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
+open FSharp.Compiler.EditorServices
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open StreamJsonRpc
+
+// ─── Shared arg types ──────────────────────────────────────────────────────────
 
 type CompletionArgs =
     { path: string
@@ -37,6 +40,7 @@ type ReferencesArgs =
 
 type WorkspaceSymbolArgs = { query: string }
 type DiagnosticsArgs = { path: string option }
+
 type SetProjectArgs =
     { projectPath: string
       workspacePath: string option
@@ -65,6 +69,54 @@ type FcsProjectSymbolUsesArgs =
       exact: bool option
       maxResults: int option }
 
+// ─── New arg types ─────────────────────────────────────────────────────────────
+
+type FcsTypeAtPositionArgs =
+    { path: string
+      line: int
+      character: int
+      text: string option
+      projectPath: string option
+      projectOptions: string list option }
+
+type FcsSignatureHelpArgs =
+    { path: string
+      line: int
+      character: int
+      text: string option
+      projectPath: string option
+      projectOptions: string list option }
+
+type FormattingArgs =
+    { path: string
+      text: string option }
+
+type CodeActionArgs =
+    { path: string
+      line: int
+      character: int
+      text: string option }
+
+type RenameArgs =
+    { path: string
+      line: int
+      character: int
+      newName: string
+      text: string option }
+
+// ─── Helper: find nearest .fsproj ──────────────────────────────────────────────
+
+let findNearestFsproj (filePath: string) : string option =
+    let rec walk (dir: string) =
+        if isNull dir then None
+        else
+            let fsprojs = Directory.GetFiles(dir, "*.fsproj")
+            if fsprojs.Length > 0 then Some fsprojs[0]
+            else walk (Path.GetDirectoryName(dir))
+    walk (Path.GetDirectoryName(Path.GetFullPath(filePath)))
+
+// ─── LSP types ─────────────────────────────────────────────────────────────────
+
 type private LspDocumentState =
     { mutable Version: int
       mutable Text: string }
@@ -79,6 +131,19 @@ type private DiagnosticsTarget(store: ConcurrentDictionary<string, JToken>) =
             let diagnostics = payload["diagnostics"]
             store[uri] <- if isNull diagnostics then JArray() :> JToken else diagnostics.DeepClone()
 
+// ─── WorkspaceLoadTarget: tracks fsharp/workspaceLoad notification ─────────────
+
+type private WorkspaceLoadTarget(setReady: unit -> unit) =
+    [<JsonRpcMethod("fsharp/workspaceLoad")>]
+    member _.WorkspaceLoad(payload: JObject) =
+        let statusToken = payload["status"]
+        if not (isNull statusToken) then
+            let status = statusToken.Value<string>()
+            if String.Equals(status, "finished", StringComparison.OrdinalIgnoreCase) then
+                setReady ()
+
+// ─── FsAutoCompleteBridge ──────────────────────────────────────────────────────
+
 type private FsAutoCompleteBridge() =
     let gate = new SemaphoreSlim(1, 1)
     let documents = ConcurrentDictionary<string, LspDocumentState>()
@@ -87,6 +152,7 @@ type private FsAutoCompleteBridge() =
     let mutable lspProcess: Process option = None
     let mutable runtimeProjectPath: string option = None
     let mutable runtimeWorkspaceRoot: string option = None
+    let mutable workspaceReady = false
 
     let parseArgs (raw: string option) =
         raw
@@ -173,8 +239,26 @@ type private FsAutoCompleteBridge() =
 
         documents.Clear()
         diagnostics.Clear()
+        workspaceReady <- false
 
     member _.DiagnosticsStore = diagnostics
+
+    // Wait until workspaceReady is true or timeout elapses
+    member _.WaitForReady(timeout: TimeSpan) : Task<bool> =
+        task {
+            let deadline = DateTime.UtcNow + timeout
+            while not workspaceReady && DateTime.UtcNow < deadline do
+                do! Task.Delay(200)
+            return workspaceReady
+        }
+
+    // Return not-ready JSON if workspace not loaded yet
+    member _.NotReadyResponse() : JToken =
+        JObject(
+            JProperty("status", "not_ready"),
+            JProperty("message", "fsautocomplete is still loading the project. Try again in a moment.")
+        )
+        :> JToken
 
     member this.SetProject(args: SetProjectArgs) : Task<JToken> =
         task {
@@ -183,33 +267,71 @@ type private FsAutoCompleteBridge() =
             if not (File.Exists(projectPath) || Directory.Exists(projectPath)) then
                 invalidArg (nameof args.projectPath) $"Path does not exist: {projectPath}"
 
+            // Detect solution files
+            let isSolution =
+                projectPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase)
+                || projectPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)
+
             let resolvedWorkspace =
-                args.workspacePath
-                |> Option.map Path.GetFullPath
-                |> Option.defaultWith (fun () -> resolveWorkspaceFromProjectPath projectPath)
+                if isSolution then
+                    // For solution files use the solution's directory
+                    Path.GetDirectoryName(projectPath)
+                else
+                    args.workspacePath
+                    |> Option.map Path.GetFullPath
+                    |> Option.defaultWith (fun () -> resolveWorkspaceFromProjectPath projectPath)
 
             let restartLsp = args.restartLsp |> Option.defaultValue true
             do! gate.WaitAsync()
 
             try
-                runtimeProjectPath <- Some projectPath
-                runtimeWorkspaceRoot <- Some resolvedWorkspace
-                Environment.SetEnvironmentVariable("FSA_PROJECT_PATH", projectPath)
+                if isSolution then
+                    runtimeProjectPath <- None
+                    runtimeWorkspaceRoot <- Some resolvedWorkspace
+                else
+                    runtimeProjectPath <- Some projectPath
+                    runtimeWorkspaceRoot <- Some resolvedWorkspace
+
+                Environment.SetEnvironmentVariable(
+                    "FSA_PROJECT_PATH",
+                    runtimeProjectPath |> Option.defaultValue "")
                 Environment.SetEnvironmentVariable("FSA_WORKSPACE_ROOT", resolvedWorkspace)
 
                 if restartLsp then
                     this.StopLspUnsafe()
+            finally
+                gate.Release() |> ignore
+
+            // After releasing gate, wait for workspace to be ready if we restarted
+            if restartLsp then
+                // Trigger EnsureStarted so we begin LSP and start listening for workspaceLoad
+                let! _ = this.EnsureStarted()
+                let! ready = this.WaitForReady(TimeSpan.FromSeconds(30.0))
+                let loadStatus = if ready then "ready" else "timeout"
 
                 return
                     JObject(
                         JProperty("status", "ok"),
-                        JProperty("projectPath", projectPath),
+                        JProperty("projectPath",
+                            runtimeProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
                         JProperty("workspaceRoot", resolvedWorkspace),
-                        JProperty("lspRestarted", restartLsp)
+                        JProperty("lspRestarted", restartLsp),
+                        JProperty("solutionMode", isSolution),
+                        JProperty("workspaceLoadStatus", loadStatus)
                     )
                     :> JToken
-            finally
-                gate.Release() |> ignore
+            else
+                return
+                    JObject(
+                        JProperty("status", "ok"),
+                        JProperty("projectPath",
+                            runtimeProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
+                        JProperty("workspaceRoot", resolvedWorkspace),
+                        JProperty("lspRestarted", restartLsp),
+                        JProperty("solutionMode", isSolution),
+                        JProperty("workspaceLoadStatus", "not_started")
+                    )
+                    :> JToken
         }
 
     member private this.EnsureStarted() : Task<JsonRpc> =
@@ -273,6 +395,7 @@ type private FsAutoCompleteBridge() =
 
                         let jsonRpc = new JsonRpc(handler)
                         jsonRpc.AddLocalRpcTarget(new DiagnosticsTarget(diagnostics)) |> ignore
+                        jsonRpc.AddLocalRpcTarget(new WorkspaceLoadTarget(fun () -> workspaceReady <- true)) |> ignore
                         jsonRpc.StartListening()
 
                         let rootUri = Uri(workspaceRoot).AbsoluteUri
@@ -340,20 +463,31 @@ type private FsAutoCompleteBridge() =
                 return uri
         }
 
+    // WithDocument: gate wraps only SyncDocument; released before LSP invoke
     member private this.WithDocument
         (path: string, providedText: string option, methodName: string, mkParams: string -> JObject)
         : Task<JToken> =
         task {
             let! jsonRpc = this.EnsureStarted()
-            do! gate.WaitAsync()
 
-            try
-                let! uri = this.SyncDocument(jsonRpc, path, providedText)
-                let parameters = mkParams uri
-                let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>(methodName, parameters)
-                return response
-            finally
-                gate.Release() |> ignore
+            if not workspaceReady then
+                return this.NotReadyResponse()
+            else
+
+            // Lock only for document sync
+            let! uri =
+                task {
+                    do! gate.WaitAsync()
+                    try
+                        return! this.SyncDocument(jsonRpc, path, providedText)
+                    finally
+                        gate.Release() |> ignore
+                }
+
+            // Gate released — StreamJsonRpc handles concurrent requests natively
+            let parameters = mkParams uri
+            let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>(methodName, parameters)
+            return response
         }
 
     member private this.PositionParams(uri: string, line: int, character: int) =
@@ -403,14 +537,15 @@ type private FsAutoCompleteBridge() =
     member this.WorkspaceSymbol(args: WorkspaceSymbolArgs) : Task<JToken> =
         task {
             let! jsonRpc = this.EnsureStarted()
-            do! gate.WaitAsync()
 
-            try
-                let parameters = jobj [ "query", jstr args.query ]
-                let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>("workspace/symbol", parameters)
-                return response
-            finally
-                gate.Release() |> ignore
+            if not workspaceReady then
+                return this.NotReadyResponse()
+            else
+
+            // No document sync needed — just invoke directly, no gate
+            let parameters = jobj [ "query", jstr args.query ]
+            let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>("workspace/symbol", parameters)
+            return response
         }
 
     member _.Diagnostics(args: DiagnosticsArgs) : Task<JToken> =
@@ -433,10 +568,140 @@ type private FsAutoCompleteBridge() =
                 return root :> JToken
         }
 
+    member this.Formatting(args: FormattingArgs) : Task<JToken> =
+        task {
+            let! jsonRpc = this.EnsureStarted()
+
+            if not workspaceReady then
+                return this.NotReadyResponse()
+            else
+
+            let fullPath = Path.GetFullPath(args.path)
+            let originalText = args.text |> Option.defaultWith (fun () -> File.ReadAllText(fullPath))
+
+            // Lock only for document sync
+            let! uri =
+                task {
+                    do! gate.WaitAsync()
+                    try
+                        return! this.SyncDocument(jsonRpc, args.path, args.text)
+                    finally
+                        gate.Release() |> ignore
+                }
+
+            let formatParams =
+                JObject(
+                    JProperty("textDocument", JObject(JProperty("uri", uri))),
+                    JProperty("options", JObject(
+                        JProperty("tabSize", 4),
+                        JProperty("insertSpaces", true)))
+                )
+
+            let! editsToken = jsonRpc.InvokeWithParameterObjectAsync<JToken>("textDocument/formatting", formatParams)
+
+            // Apply text edits to produce formatted result
+            let applyEdits (text: string) (edits: JArray) =
+                // Sort edits in reverse order (bottom to top) to preserve positions
+                let getRangeStart (e: JToken) =
+                    let r = e["range"]
+                    let s = r["start"]
+                    s["line"].Value<int>(), s["character"].Value<int>()
+
+                let sortedEdits =
+                    edits
+                    |> Seq.cast<JToken>
+                    |> Seq.sortByDescending (fun e ->
+                        let sl, sc = getRangeStart e
+                        sl, sc)
+                    |> Seq.toArray
+
+                let lines = text.Split('\n') |> Array.map (fun l -> l.TrimEnd('\r'))
+
+                let applyEdit (linesArr: string array) (edit: JToken) =
+                    let range = edit["range"]
+                    let startPos = range["start"]
+                    let endPos = range["end"]
+                    let startLine = startPos["line"].Value<int>()
+                    let startChar = startPos["character"].Value<int>()
+                    let endLine = endPos["line"].Value<int>()
+                    let endChar = endPos["character"].Value<int>()
+                    let newText = edit["newText"].Value<string>()
+
+                    let before =
+                        if startLine < linesArr.Length then
+                            linesArr[startLine][..startChar - 1]
+                        else ""
+                    let after =
+                        if endLine < linesArr.Length then
+                            let endLineText = linesArr[endLine]
+                            if endChar < endLineText.Length then endLineText[endChar..] else ""
+                        else ""
+
+                    let replacement = before + newText + after
+                    let replacementLines = replacement.Split('\n')
+
+                    let result = System.Collections.Generic.List<string>()
+                    for i in 0 .. startLine - 1 do
+                        result.Add(linesArr[i])
+                    for l in replacementLines do
+                        result.Add(l)
+                    for i in endLine + 1 .. linesArr.Length - 1 do
+                        result.Add(linesArr[i])
+                    result.ToArray()
+
+                let mutable currentLines = lines
+                for edit in sortedEdits do
+                    currentLines <- applyEdit currentLines edit
+                String.concat "\n" currentLines
+
+            let formatted =
+                match editsToken with
+                | :? JArray as edits when edits.Count > 0 ->
+                    applyEdits originalText edits
+                | _ -> originalText
+
+            return
+                JObject(
+                    JProperty("status", "ok"),
+                    JProperty("formatted", formatted),
+                    JProperty("edits", if editsToken :? JArray then editsToken else JArray() :> JToken)
+                )
+                :> JToken
+        }
+
+    member this.CodeAction(args: CodeActionArgs) : Task<JToken> =
+        this.WithDocument(
+            args.path,
+            args.text,
+            "textDocument/codeAction",
+            fun uri ->
+                let pos = JObject(JProperty("line", args.line), JProperty("character", args.character))
+                JObject(
+                    JProperty("textDocument", JObject(JProperty("uri", uri))),
+                    JProperty("range", JObject(JProperty("start", pos), JProperty("end", pos))),
+                    JProperty("context", JObject(JProperty("diagnostics", JArray())))
+                )
+        )
+
+    member this.Rename(args: RenameArgs) : Task<JToken> =
+        this.WithDocument(
+            args.path,
+            args.text,
+            "textDocument/rename",
+            fun uri ->
+                JObject(
+                    JProperty("textDocument", JObject(JProperty("uri", uri))),
+                    JProperty("position", JObject(JProperty("line", args.line), JProperty("character", args.character))),
+                    JProperty("newName", args.newName)
+                )
+        )
+
     interface IDisposable with
         member this.Dispose() =
             this.StopLspUnsafe()
             gate.Dispose()
+
+// ─── FcsBridge ─────────────────────────────────────────────────────────────────
 
 type private FcsBridge() =
     let checker =
@@ -445,6 +710,10 @@ type private FcsBridge() =
             keepAllBackgroundResolutions = true,
             keepAllBackgroundSymbolUses = true
         )
+
+    // Caches keyed by a string combining projectPath + projectOptions hash
+    let optionsCache = ConcurrentDictionary<string, FSharpProjectOptions>()
+    let projectResultsCache = ConcurrentDictionary<string, FSharpCheckProjectResults>()
 
     let asTask (workflow: Async<'T>) : Task<'T> =
         Async.StartAsTask(workflow, cancellationToken = CancellationToken.None)
@@ -508,12 +777,21 @@ type private FcsBridge() =
         )
         :> JToken
 
+    // Build a stable cache key from projectPath and projectOptions list
+    let makeCacheKey (projectPath: string option) (projectOptions: string list option) =
+        let pp = projectPath |> Option.defaultValue ""
+        let po =
+            projectOptions
+            |> Option.map (fun opts -> String.concat "|" opts)
+            |> Option.defaultValue ""
+        $"{pp}::{po}"
+
     member private _.ResolveProjectOptions
         (path: string, text: string, projectPath: string option, projectOptions: string list option)
         : Task<FSharpProjectOptions * string> =
         task {
             let fullPath = normalizePath path
-            let sourceText = SourceText.ofString text
+            let cacheKey = makeCacheKey projectPath projectOptions
 
             match projectOptions with
             | Some options when not options.IsEmpty ->
@@ -522,13 +800,44 @@ type private FcsBridge() =
                     |> Option.defaultValue (Path.ChangeExtension(fullPath, ".fsproj"))
                     |> normalizePath
 
-                let resolvedOptions =
-                    checker.GetProjectOptionsFromCommandLineArgs(projectFileName, options |> List.toArray)
-
-                return resolvedOptions, "commandLineArgs"
+                match optionsCache.TryGetValue(cacheKey) with
+                | true, cached ->
+                    return cached, "commandLineArgs"
+                | false, _ ->
+                    let resolvedOptions =
+                        checker.GetProjectOptionsFromCommandLineArgs(projectFileName, options |> List.toArray)
+                    optionsCache[cacheKey] <- resolvedOptions
+                    return resolvedOptions, "commandLineArgs"
             | _ ->
-                let! scriptOptions, _ = checker.GetProjectOptionsFromScript(fullPath, sourceText) |> asTask
-                return scriptOptions, "scriptInference"
+                // Try auto-discover .fsproj
+                let discoveredFsproj = findNearestFsproj fullPath
+                match discoveredFsproj with
+                | Some fsprojPath ->
+                    let fsprojKey = $"fsproj::{fsprojPath}"
+                    match optionsCache.TryGetValue(fsprojKey) with
+                    | true, cached ->
+                        return cached, "auto-discovered"
+                    | false, _ ->
+                        // Use GetProjectOptionsFromScript as fallback since we can't easily
+                        // call Ionide's MSBuild evaluation without a proper toolsPath setup
+                        let sourceText = SourceText.ofString text
+                        let! scriptOptions, _ = checker.GetProjectOptionsFromScript(fullPath, sourceText) |> asTask
+                        // Override the project file name to the discovered .fsproj
+                        let discovered =
+                            { scriptOptions with
+                                ProjectFileName = fsprojPath }
+                        optionsCache[fsprojKey] <- discovered
+                        return discovered, "auto-discovered"
+                | None ->
+                    let scriptKey = $"script::{fullPath}"
+                    match optionsCache.TryGetValue(scriptKey) with
+                    | true, cached ->
+                        return cached, "scriptInference"
+                    | false, _ ->
+                        let sourceText = SourceText.ofString text
+                        let! scriptOptions, _ = checker.GetProjectOptionsFromScript(fullPath, sourceText) |> asTask
+                        optionsCache[scriptKey] <- scriptOptions
+                        return scriptOptions, "scriptInference"
         }
 
     member private this.PrepareCheckContext
@@ -645,7 +954,18 @@ type private FcsBridge() =
             let! _, _, optionsSource, projectOptions, _, _ =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
 
-            let! projectResults = checker.ParseAndCheckProject(projectOptions) |> asTask
+            // Use cached project results if available
+            let cacheKey = makeCacheKey args.projectPath args.projectOptions
+            let! projectResults, cached =
+                task {
+                    match projectResultsCache.TryGetValue(cacheKey) with
+                    | true, existing ->
+                        return existing, true
+                    | false, _ ->
+                        let! results = checker.ParseAndCheckProject(projectOptions) |> asTask
+                        projectResultsCache[cacheKey] <- results
+                        return results, false
+                }
 
             let exact = args.exact |> Option.defaultValue false
             let maxResults = args.maxResults |> Option.defaultValue 500
@@ -681,6 +1001,7 @@ type private FcsBridge() =
                     JProperty("projectFileName", projectOptions.ProjectFileName),
                     JProperty("query", query),
                     JProperty("exact", exact),
+                    JProperty("cached", cached),
                     JProperty("totalProjectSymbolUses", allUses.Length),
                     JProperty("matchedCount", matchedUses.Length),
                     JProperty("uses", JArray(matchedUses)),
@@ -688,6 +1009,192 @@ type private FcsBridge() =
                 )
                 :> JToken
         }
+
+    member this.TypeAtPosition(args: FcsTypeAtPositionArgs) : Task<JToken> =
+        task {
+            let! path, source, optionsSource, _, _, checkedResults =
+                this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
+
+            match checkedResults with
+            | None ->
+                return
+                    JObject(
+                        JProperty("status", "aborted"),
+                        JProperty("message", "Type checking was aborted.")
+                    )
+                    :> JToken
+            | Some checkResults ->
+                // FCS uses 1-based lines; assume input is 0-based (LSP convention)
+                let fcsLine = args.line + 1
+                let fcsCol = args.character
+
+                // Get the line text for FCS APIs
+                let lines = source.Split('\n')
+                let lineText =
+                    if fcsLine - 1 < lines.Length then lines[fcsLine - 1].TrimEnd('\r')
+                    else ""
+
+                let symbolUse =
+                    checkResults.GetSymbolUseAtLocation(fcsLine, fcsCol, lineText, [])
+
+                let toolTip =
+                    checkResults.GetToolTip(fcsLine, fcsCol, lineText, [], FSharp.Compiler.Tokenization.FSharpTokenTag.IDENT)
+
+                let typeString =
+                    match toolTip with
+                    | ToolTipText elements ->
+                        elements
+                        |> List.choose (fun el ->
+                            match el with
+                            | ToolTipElement.Group items ->
+                                items
+                                |> List.map (fun item ->
+                                    item.MainDescription
+                                    |> Array.map (fun tagged -> tagged.Text)
+                                    |> String.concat "")
+                                |> Some
+                            | _ -> None)
+                        |> List.collect id
+                        |> String.concat "\n"
+
+                let xmlDoc =
+                    match toolTip with
+                    | ToolTipText elements ->
+                        elements
+                        |> List.choose (fun el ->
+                            match el with
+                            | ToolTipElement.Group items ->
+                                items
+                                |> List.choose (fun item ->
+                                    match item.XmlDoc with
+                                    | FSharpXmlDoc.FromXmlText xmlText ->
+                                        Some (xmlText.GetXmlText())
+                                    | _ -> None)
+                                |> Some
+                            | _ -> None)
+                        |> List.collect id
+                        |> String.concat "\n"
+
+                match symbolUse with
+                | None ->
+                    return
+                        JObject(
+                            JProperty("status", "no_symbol"),
+                            JProperty("message", "No symbol at this position"),
+                            JProperty("file", path),
+                            JProperty("line", args.line),
+                            JProperty("character", args.character),
+                            JProperty("typeString", typeString)
+                        )
+                        :> JToken
+                | Some su ->
+                    return
+                        JObject(
+                            JProperty("status", "ok"),
+                            JProperty("file", path),
+                            JProperty("line", args.line),
+                            JProperty("character", args.character),
+                            JProperty("optionsSource", optionsSource),
+                            JProperty("symbolName", su.Symbol.DisplayName),
+                            JProperty("fullName", jstrOrNull su.Symbol.FullName),
+                            JProperty("typeString", typeString),
+                            JProperty("xmlDoc", xmlDoc)
+                        )
+                        :> JToken
+        }
+
+    member this.SignatureHelp(args: FcsSignatureHelpArgs) : Task<JToken> =
+        task {
+            let! path, source, optionsSource, _, _, checkedResults =
+                this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
+
+            match checkedResults with
+            | None ->
+                return
+                    JObject(
+                        JProperty("status", "aborted"),
+                        JProperty("message", "Type checking was aborted.")
+                    )
+                    :> JToken
+            | Some checkResults ->
+                // FCS uses 1-based lines; assume input is 0-based (LSP convention)
+                let fcsLine = args.line + 1
+                let fcsCol = args.character
+
+                let lines = source.Split('\n')
+                let lineText =
+                    if fcsLine - 1 < lines.Length then lines[fcsLine - 1].TrimEnd('\r')
+                    else ""
+
+                let methodsOpt =
+                    checkResults.GetMethodsAsSymbols(fcsLine, fcsCol, lineText, [])
+
+                let overloads =
+                    match methodsOpt with
+                    | None -> [||]
+                    | Some symbolUses ->
+                        symbolUses
+                        |> List.choose (fun su ->
+                            match su.Symbol with
+                            | :? FSharpMemberOrFunctionOrValue as m ->
+                                let paramGroups = m.CurriedParameterGroups
+                                let parameters =
+                                    paramGroups
+                                    |> Seq.collect id
+                                    |> Seq.map (fun p ->
+                                        JObject(
+                                            JProperty("name", p.Name |> Option.defaultValue ""),
+                                            JProperty("type", p.Type.BasicQualifiedName)
+                                        )
+                                        :> JToken)
+                                    |> Seq.toArray
+
+                                let returnType =
+                                    try m.ReturnParameter.Type.BasicQualifiedName
+                                    with _ -> ""
+
+                                let signature =
+                                    let paramStr =
+                                        parameters
+                                        |> Array.map (fun p ->
+                                            let pName = p["name"].Value<string>()
+                                            let pType = p["type"].Value<string>()
+                                            $"{pName}: {pType}")
+                                        |> String.concat " -> "
+                                    $"{m.DisplayName}({paramStr}) -> {returnType}"
+
+                                Some (JObject(
+                                    JProperty("signature", signature),
+                                    JProperty("parameters", JArray(parameters)),
+                                    JProperty("returnType", returnType)
+                                )
+                                :> JToken)
+                            | _ -> None)
+                        |> List.toArray
+
+                if overloads.Length = 0 then
+                    return
+                        JObject(
+                            JProperty("status", "no_overloads"),
+                            JProperty("file", path),
+                            JProperty("line", args.line),
+                            JProperty("character", args.character)
+                        )
+                        :> JToken
+                else
+                    return
+                        JObject(
+                            JProperty("status", "ok"),
+                            JProperty("file", path),
+                            JProperty("line", args.line),
+                            JProperty("character", args.character),
+                            JProperty("optionsSource", optionsSource),
+                            JProperty("overloads", JArray(overloads))
+                        )
+                        :> JToken
+        }
+
+// ─── MCP helpers ───────────────────────────────────────────────────────────────
 
 let private renderToken (token: JToken) =
     token.ToString(Newtonsoft.Json.Formatting.Indented)
@@ -700,6 +1207,8 @@ let private toolResult (work: Task<JToken>) : Task<Result<Content list, McpError
         with ex ->
             return Error(McpError.TransportError ex.Message)
     }
+
+// ─── CLI helpers ───────────────────────────────────────────────────────────────
 
 type private CliParseResult =
     | Start
@@ -785,6 +1294,8 @@ let private applyCliOverrides (argv: string array) =
 
     loop 0
 
+// ─── Entry point ───────────────────────────────────────────────────────────────
+
 [<EntryPoint>]
 let main argv =
     match applyCliOverrides argv with
@@ -856,7 +1367,7 @@ let main argv =
                 tool (
                     TypedTool.define<SetProjectArgs>
                         "set_project"
-                        "Sets active project/workspace for fsautocomplete and optionally restarts LSP."
+                        "Sets active project/workspace for fsautocomplete. Accepts .fsproj, .sln, .slnx, or directory. Waits up to 30s for workspace load."
                         (fun args -> toolResult (bridge.SetProject args))
                     |> unwrapResult
                 )
@@ -880,8 +1391,48 @@ let main argv =
                 tool (
                     TypedTool.define<FcsProjectSymbolUsesArgs>
                         "fcs_project_symbol_uses"
-                        "FCS project-wide symbol use search by symbol name/fullname."
+                        "FCS project-wide symbol use search by symbol name/fullname. Results are cached per project."
                         (fun args -> toolResult (fcsBridge.ProjectSymbolUses args))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<FcsTypeAtPositionArgs>
+                        "fcs_type_at_position"
+                        "Returns the F# type and symbol info at a cursor position. line/character are 0-based (LSP convention)."
+                        (fun args -> toolResult (fcsBridge.TypeAtPosition args))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<FcsSignatureHelpArgs>
+                        "fcs_signature_help"
+                        "Returns method signature and overloads at a cursor position. line/character are 0-based (LSP convention)."
+                        (fun args -> toolResult (fcsBridge.SignatureHelp args))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<FormattingArgs>
+                        "textDocument_formatting"
+                        "Formats F# code via fsautocomplete/Fantomas. Returns formatted text and applied edits."
+                        (fun args -> toolResult (bridge.Formatting args))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<CodeActionArgs>
+                        "textDocument_codeAction"
+                        "Returns available code actions at a position via fsautocomplete. line/character are 0-based."
+                        (fun args -> toolResult (bridge.CodeAction args))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<RenameArgs>
+                        "textDocument_rename"
+                        "Renames a symbol at a position via fsautocomplete. line/character are 0-based."
+                        (fun args -> toolResult (bridge.Rename args))
                     |> unwrapResult
                 )
 

--- a/Program.fs
+++ b/Program.fs
@@ -106,7 +106,7 @@ type RenameArgs =
 
 // ─── Helper: find nearest .fsproj ──────────────────────────────────────────────
 
-let findNearestFsproj (filePath: string) : string option =
+let private findNearestFsproj (filePath: string) : string option =
     let rec walk (dir: string) =
         if isNull dir then None
         else
@@ -148,10 +148,13 @@ type private FsAutoCompleteBridge() =
     let gate = new SemaphoreSlim(1, 1)
     let documents = ConcurrentDictionary<string, LspDocumentState>()
     let diagnostics = ConcurrentDictionary<string, JToken>()
+    [<VolatileField>]
     let mutable rpc: JsonRpc option = None
     let mutable lspProcess: Process option = None
     let mutable runtimeProjectPath: string option = None
     let mutable runtimeWorkspaceRoot: string option = None
+    let workspaceReadyEvent = new ManualResetEventSlim(false)
+    [<VolatileField>]
     let mutable workspaceReady = false
 
     let parseArgs (raw: string option) =
@@ -240,16 +243,14 @@ type private FsAutoCompleteBridge() =
         documents.Clear()
         diagnostics.Clear()
         workspaceReady <- false
+        workspaceReadyEvent.Reset()
 
     member _.DiagnosticsStore = diagnostics
 
     // Wait until workspaceReady is true or timeout elapses
     member _.WaitForReady(timeout: TimeSpan) : Task<bool> =
         task {
-            let deadline = DateTime.UtcNow + timeout
-            while not workspaceReady && DateTime.UtcNow < deadline do
-                do! Task.Delay(200)
-            return workspaceReady
+            return workspaceReadyEvent.Wait(timeout)
         }
 
     // Return not-ready JSON if workspace not loaded yet
@@ -284,23 +285,26 @@ type private FsAutoCompleteBridge() =
             let restartLsp = args.restartLsp |> Option.defaultValue true
             do! gate.WaitAsync()
 
-            try
-                if isSolution then
-                    runtimeProjectPath <- None
-                    runtimeWorkspaceRoot <- Some resolvedWorkspace
-                else
-                    runtimeProjectPath <- Some projectPath
-                    runtimeWorkspaceRoot <- Some resolvedWorkspace
+            let capturedProjectPath, capturedWorkspaceRoot =
+                try
+                    if isSolution then
+                        runtimeProjectPath <- None
+                        runtimeWorkspaceRoot <- Some resolvedWorkspace
+                    else
+                        runtimeProjectPath <- Some projectPath
+                        runtimeWorkspaceRoot <- Some resolvedWorkspace
 
-                Environment.SetEnvironmentVariable(
-                    "FSA_PROJECT_PATH",
-                    runtimeProjectPath |> Option.defaultValue "")
-                Environment.SetEnvironmentVariable("FSA_WORKSPACE_ROOT", resolvedWorkspace)
+                    Environment.SetEnvironmentVariable(
+                        "FSA_PROJECT_PATH",
+                        runtimeProjectPath |> Option.defaultValue "")
+                    Environment.SetEnvironmentVariable("FSA_WORKSPACE_ROOT", resolvedWorkspace)
 
-                if restartLsp then
-                    this.StopLspUnsafe()
-            finally
-                gate.Release() |> ignore
+                    if restartLsp then
+                        this.StopLspUnsafe()
+
+                    runtimeProjectPath, resolvedWorkspace
+                finally
+                    gate.Release() |> ignore
 
             // After releasing gate, wait for workspace to be ready if we restarted
             if restartLsp then
@@ -313,8 +317,8 @@ type private FsAutoCompleteBridge() =
                     JObject(
                         JProperty("status", "ok"),
                         JProperty("projectPath",
-                            runtimeProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
-                        JProperty("workspaceRoot", resolvedWorkspace),
+                            capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
+                        JProperty("workspaceRoot", capturedWorkspaceRoot),
                         JProperty("lspRestarted", restartLsp),
                         JProperty("solutionMode", isSolution),
                         JProperty("workspaceLoadStatus", loadStatus)
@@ -325,8 +329,8 @@ type private FsAutoCompleteBridge() =
                     JObject(
                         JProperty("status", "ok"),
                         JProperty("projectPath",
-                            runtimeProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
-                        JProperty("workspaceRoot", resolvedWorkspace),
+                            capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
+                        JProperty("workspaceRoot", capturedWorkspaceRoot),
                         JProperty("lspRestarted", restartLsp),
                         JProperty("solutionMode", isSolution),
                         JProperty("workspaceLoadStatus", "not_started")
@@ -395,7 +399,9 @@ type private FsAutoCompleteBridge() =
 
                         let jsonRpc = new JsonRpc(handler)
                         jsonRpc.AddLocalRpcTarget(new DiagnosticsTarget(diagnostics)) |> ignore
-                        jsonRpc.AddLocalRpcTarget(new WorkspaceLoadTarget(fun () -> workspaceReady <- true)) |> ignore
+                        jsonRpc.AddLocalRpcTarget(new WorkspaceLoadTarget(fun () ->
+                            workspaceReady <- true
+                            workspaceReadyEvent.Set())) |> ignore
                         jsonRpc.StartListening()
 
                         let rootUri = Uri(workspaceRoot).AbsoluteUri
@@ -827,7 +833,7 @@ type private FcsBridge() =
                             { scriptOptions with
                                 ProjectFileName = fsprojPath }
                         optionsCache[fsprojKey] <- discovered
-                        return discovered, "auto-discovered"
+                        return discovered, "auto-discovered-script-fallback"
                 | None ->
                     let scriptKey = $"script::{fullPath}"
                     match optionsCache.TryGetValue(scriptKey) with
@@ -1103,6 +1109,10 @@ type private FcsBridge() =
                         :> JToken
         }
 
+    member _.ClearCaches() =
+        optionsCache.Clear()
+        projectResultsCache.Clear()
+
     member this.SignatureHelp(args: FcsSignatureHelpArgs) : Task<JToken> =
         task {
             let! path, source, optionsSource, _, _, checkedResults =
@@ -1160,7 +1170,7 @@ type private FcsBridge() =
                                             let pName = p["name"].Value<string>()
                                             let pType = p["type"].Value<string>()
                                             $"{pName}: {pType}")
-                                        |> String.concat " -> "
+                                        |> String.concat ", "
                                     $"{m.DisplayName}({paramStr}) -> {returnType}"
 
                                 Some (JObject(
@@ -1368,7 +1378,12 @@ let main argv =
                     TypedTool.define<SetProjectArgs>
                         "set_project"
                         "Sets active project/workspace for fsautocomplete. Accepts .fsproj, .sln, .slnx, or directory. Waits up to 30s for workspace load."
-                        (fun args -> toolResult (bridge.SetProject args))
+                        (fun args ->
+                            toolResult (task {
+                                let! result = bridge.SetProject args
+                                fcsBridge.ClearCaches()
+                                return result
+                            }))
                     |> unwrapResult
                 )
 

--- a/tests/FsLangMcp.Tests/FcsBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/FcsBridgeTests.fs
@@ -1,0 +1,141 @@
+module FsLangMcp.Tests.FcsBridgeTests
+
+open System
+open System.IO
+open System.Threading
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Text
+open Xunit
+
+// Helpers
+
+let private checker =
+    FSharpChecker.Create(
+        keepAssemblyContents = true,
+        keepAllBackgroundResolutions = true,
+        keepAllBackgroundSymbolUses = true
+    )
+
+let private asTask workflow =
+    Async.StartAsTask(workflow, cancellationToken = CancellationToken.None)
+
+let private normalizePath (path: string) = Path.GetFullPath(path)
+
+/// Write a temp .fs file, return its path
+let private writeTempFs (content: string) =
+    let path = Path.Combine(Path.GetTempPath(), $"fslangmcp_test_{Guid.NewGuid()}.fs")
+    File.WriteAllText(path, content)
+    path
+
+[<Fact>]
+let ``fcs_parse_and_check_file succeeds on valid F# snippet`` () =
+    let src = """
+module TestModule
+
+let add x y = x + y
+
+let result = add 1 2
+"""
+    let path = writeTempFs src
+    try
+        let sourceText = SourceText.ofString src
+        let getOptions =
+            task {
+                let! opts, _ = checker.GetProjectOptionsFromScript(path, sourceText) |> asTask
+                return opts
+            }
+        let opts = getOptions.GetAwaiter().GetResult()
+        let parsingOpts, _ = checker.GetParsingOptionsFromProjectOptions(opts)
+        let parseTask = checker.ParseFile(path, sourceText, parsingOpts) |> asTask
+        let parseResults = parseTask.GetAwaiter().GetResult()
+        let checkTask = checker.ParseAndCheckFileInProject(path, 0, sourceText, opts) |> asTask
+        let _, checkAnswer = checkTask.GetAwaiter().GetResult()
+
+        match checkAnswer with
+        | FSharpCheckFileAnswer.Succeeded results ->
+            Assert.True(results.HasFullTypeCheckInfo, "Should have full type check info")
+            Assert.False(parseResults.ParseHadErrors, "Parse should not have errors")
+        | FSharpCheckFileAnswer.Aborted ->
+            Assert.Fail("Type checking was aborted unexpectedly")
+    finally
+        if File.Exists(path) then File.Delete(path)
+
+[<Fact>]
+let ``fcs_file_symbols returns expected symbols from a simple module`` () =
+    let src = """
+module SymbolModule
+
+let myValue = 42
+
+let myFunction x = x + 1
+
+type MyRecord = { Field1: int; Field2: string }
+"""
+    let path = writeTempFs src
+    try
+        let sourceText = SourceText.ofString src
+        let getOptions =
+            task {
+                let! opts, _ = checker.GetProjectOptionsFromScript(path, sourceText) |> asTask
+                return opts
+            }
+        let opts = getOptions.GetAwaiter().GetResult()
+        let parsingOpts, _ = checker.GetParsingOptionsFromProjectOptions(opts)
+        let parseTask = checker.ParseFile(path, sourceText, parsingOpts) |> asTask
+        let _ = parseTask.GetAwaiter().GetResult()
+        let checkTask = checker.ParseAndCheckFileInProject(path, 0, sourceText, opts) |> asTask
+        let _, checkAnswer = checkTask.GetAwaiter().GetResult()
+
+        match checkAnswer with
+        | FSharpCheckFileAnswer.Succeeded results ->
+            let definedSymbols =
+                results.GetAllUsesOfAllSymbolsInFile()
+                |> Seq.filter (fun su -> su.IsFromDefinition)
+                |> Seq.map (fun su -> su.Symbol.DisplayName)
+                |> Seq.toList
+
+            // Should contain our defined names
+            Assert.Contains("myValue", definedSymbols)
+            Assert.Contains("myFunction", definedSymbols)
+            Assert.Contains("MyRecord", definedSymbols)
+        | FSharpCheckFileAnswer.Aborted ->
+            Assert.Fail("Type checking was aborted unexpectedly")
+    finally
+        if File.Exists(path) then File.Delete(path)
+
+[<Fact>]
+let ``fcs_project_symbol_uses finds a symbol by name`` () =
+    let src = """
+module SearchModule
+
+let targetFunction x y = x * y
+
+let callSite = targetFunction 3 4
+"""
+    let path = writeTempFs src
+    try
+        let sourceText = SourceText.ofString src
+        let getOptions =
+            task {
+                let! opts, _ = checker.GetProjectOptionsFromScript(path, sourceText) |> asTask
+                return opts
+            }
+        let opts = getOptions.GetAwaiter().GetResult()
+        let projectTask = checker.ParseAndCheckProject(opts) |> asTask
+        let projectResults = projectTask.GetAwaiter().GetResult()
+
+        let allUses = projectResults.GetAllUsesOfAllSymbols()
+
+        let targetUses =
+            allUses
+            |> Seq.filter (fun su ->
+                su.Symbol.DisplayName.Contains("targetFunction", StringComparison.OrdinalIgnoreCase))
+            |> Seq.toArray
+
+        Assert.True(targetUses.Length > 0, "Should find at least one use of targetFunction")
+
+        // Should find both definition and call site
+        let hasDefinition = targetUses |> Array.exists (fun su -> su.IsFromDefinition)
+        Assert.True(hasDefinition, "Should find the definition of targetFunction")
+    finally
+        if File.Exists(path) then File.Delete(path)

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,16 +11,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Compiler.Service" Version="43.12.201" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../../FsLangMcp.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="FcsBridgeTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../FsLangMcp.fsproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #1
Closes #2
Closes #3
Closes #4
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #12

## Changes

### Bug fixes
- #1: LSP wait for project load — `WorkspaceLoadTarget` tracks `fsharp/workspaceLoad` notification; `SetProject` waits up to 30s; tools return `{"status": "not_ready"}` instead of error
- #2: FCS project options caching — `ConcurrentDictionary` caches `FSharpProjectOptions` and `FSharpCheckProjectResults` by key
- #10: Fixed global lock — gate released before LSP invoke; concurrent requests now truly parallel

### New tools
- #3: `fcs_type_at_position` — returns F# type + symbol info at cursor
- #7: `textDocument_formatting` — formats F# via fsautocomplete/Fantomas
- #8: `textDocument_codeAction`, `textDocument_rename` — LSP code actions and rename
- #12: `fcs_signature_help` — method overloads and parameter info at cursor

### Features
- #4: Auto-detect `.fsproj` from file path — no `set_project` required for FCS tools
- #9: `.sln`/`.slnx` accepted as project path in `set_project`

### Tests
- #6: xUnit test project for FcsBridge (3 tests, all passing)