### PR TITLE
fix: add [<VolatileField>] to lspProcess and stderrPump (#30)

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -152,6 +152,7 @@ type private FsAutoCompleteBridge() =
     let diagnostics = ConcurrentDictionary<string, JToken>()
     [<VolatileField>]
     let mutable rpc: JsonRpc option = None
+    [<VolatileField>]
     let mutable lspProcess: Process option = None
     [<VolatileField>]
     let mutable runtimeProjectPath: string option = None
@@ -160,6 +161,7 @@ type private FsAutoCompleteBridge() =
     let workspaceReadyEvent = new ManualResetEventSlim(false)
     [<VolatileField>]
     let mutable workspaceReady = false
+    [<VolatileField>]
     let mutable stderrPump: Task option = None
 
     let parseArgs (raw: string option) =


### PR DESCRIPTION
Closes #30

## What

Add `[<VolatileField>]` to `lspProcess` and `stderrPump` in `FsAutoCompleteBridge`.

## Why

`Dispose()` calls `StopLspUnsafe()` without acquiring the semaphore gate. A thread calling `Dispose()` concurrently with a thread inside `StartLspUnsafe()` could observe stale values for these fields due to CPU caching. All other mutable bridge fields (`rpc`, `runtimeProjectPath`, `runtimeWorkspaceRoot`, `workspaceReady`) already had `[<VolatileField>]` — this brings the remaining two into consistency.

## Verification

- Build: 0 errors, 0 warnings
- Unit tests: 3/3 pass
- Integration smoke tests: SimpleLib ✓, MultiProject ✓ (15 tools verified, no crashes)