### PR TITLE
feat: structured ToolError DU with errorKind field (#20)

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -18,6 +18,21 @@ open StreamJsonRpc
 open Ionide.ProjInfo
 open Ionide.ProjInfo.Types
 
+// ─── Tool error DU ─────────────────────────────────────────────────────────────
+
+type ToolError =
+    | InvalidArgs  of string
+    | NotReady     of string
+    | InfraFailure of exn
+    | FcsAborted   of string
+
+let private toolErrorToJson (err: ToolError) : string =
+    match err with
+    | InvalidArgs msg  -> sprintf """{"errorKind":"InvalidArgs","message":%s}"""   (Newtonsoft.Json.JsonConvert.SerializeObject msg)
+    | NotReady msg     -> sprintf """{"errorKind":"NotReady","message":%s}"""      (Newtonsoft.Json.JsonConvert.SerializeObject msg)
+    | InfraFailure ex  -> sprintf """{"errorKind":"InfraFailure","message":%s}"""  (Newtonsoft.Json.JsonConvert.SerializeObject ex.Message)
+    | FcsAborted msg   -> sprintf """{"errorKind":"FcsAborted","message":%s}"""    (Newtonsoft.Json.JsonConvert.SerializeObject msg)
+
 // ─── Shared arg types ──────────────────────────────────────────────────────────
 
 type CompletionArgs =
@@ -1289,12 +1304,23 @@ let private toolResult (work: Task<JToken>) : Task<Result<Content list, McpError
             let! payload = work
             return Ok [ Content.text (renderToken payload) ]
         with
+        | :? OperationCanceledException as ex ->
+            // TaskCanceledException is a subclass of OperationCanceledException — both caught here
+            let err = FcsAborted ex.Message
+            return Error(McpError.TransportError (toolErrorToJson err))
         | :? ArgumentException as ex ->
-            return Error(McpError.TransportError $"[InvalidArgs] {ex.Message}")
-        | :? FileNotFoundException as ex ->
-            return Error(McpError.TransportError $"[FileNotFound] {ex.Message}")
+            let err = InvalidArgs ex.Message
+            return Error(McpError.TransportError (toolErrorToJson err))
+        | ex when ex.Message.IndexOf("not ready", StringComparison.OrdinalIgnoreCase) >= 0
+               || ex.Message.IndexOf("NotReady", StringComparison.Ordinal) >= 0 ->
+            let err = NotReady ex.Message
+            return Error(McpError.TransportError (toolErrorToJson err))
+        | ex when ex.Message.StartsWith("Invalid", StringComparison.OrdinalIgnoreCase) ->
+            let err = InvalidArgs ex.Message
+            return Error(McpError.TransportError (toolErrorToJson err))
         | ex ->
-            return Error(McpError.TransportError $"[Error] {ex.Message}")
+            let err = InfraFailure ex
+            return Error(McpError.TransportError (toolErrorToJson err))
     }
 
 // ─── CLI helpers ───────────────────────────────────────────────────────────────

--- a/Program.fs
+++ b/Program.fs
@@ -1313,6 +1313,9 @@ let private toolResult (work: Task<JToken>) : Task<Result<Content list, McpError
         | :? ArgumentException as ex ->
             let err = InvalidArgs ex.Message
             return Error(McpError.TransportError (toolErrorToJson err))
+        // Guard for external process exceptions that surface "not ready" text.
+        // Note: current not-ready paths return via NotReadyResponse() (no exception),
+        // so this arm is defensive — it would fire if a future external dep raises.
         | ex when ex.Message.IndexOf("not ready", StringComparison.OrdinalIgnoreCase) >= 0
                || ex.Message.IndexOf("NotReady", StringComparison.Ordinal) >= 0 ->
             let err = NotReady ex.Message

--- a/Program.fs
+++ b/Program.fs
@@ -25,6 +25,7 @@ type ToolError =
     | NotReady     of string
     | InfraFailure of exn
     | FcsAborted   of string
+    | FileNotFound of string
 
 let private toolErrorToJson (err: ToolError) : string =
     match err with
@@ -32,6 +33,7 @@ let private toolErrorToJson (err: ToolError) : string =
     | NotReady msg     -> sprintf """{"errorKind":"NotReady","message":%s}"""      (Newtonsoft.Json.JsonConvert.SerializeObject msg)
     | InfraFailure ex  -> sprintf """{"errorKind":"InfraFailure","message":%s}"""  (Newtonsoft.Json.JsonConvert.SerializeObject ex.Message)
     | FcsAborted msg   -> sprintf """{"errorKind":"FcsAborted","message":%s}"""    (Newtonsoft.Json.JsonConvert.SerializeObject msg)
+    | FileNotFound msg -> sprintf """{"errorKind":"FileNotFound","message":%s}"""  (Newtonsoft.Json.JsonConvert.SerializeObject msg)
 
 // ─── Shared arg types ──────────────────────────────────────────────────────────
 
@@ -1315,8 +1317,8 @@ let private toolResult (work: Task<JToken>) : Task<Result<Content list, McpError
                || ex.Message.IndexOf("NotReady", StringComparison.Ordinal) >= 0 ->
             let err = NotReady ex.Message
             return Error(McpError.TransportError (toolErrorToJson err))
-        | ex when ex.Message.StartsWith("Invalid", StringComparison.OrdinalIgnoreCase) ->
-            let err = InvalidArgs ex.Message
+        | :? System.IO.FileNotFoundException as ex ->
+            let err = FileNotFound ex.Message
             return Error(McpError.TransportError (toolErrorToJson err))
         | ex ->
             let err = InfraFailure ex

--- a/tests/FsLangMcp.Tests/FcsBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/FcsBridgeTests.fs
@@ -6,7 +6,57 @@ open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Text
+open Newtonsoft.Json
 open Xunit
+
+// ─── ToolError serialization tests ────────────────────────────────────────────
+// These tests replicate the serialization pattern from Program.fs inline,
+// providing regression coverage without requiring a reference to the Exe project.
+
+let private serialize (msg: string) = JsonConvert.SerializeObject msg
+
+[<Fact>]
+let ``ToolError InvalidArgs serializes with correct errorKind and message`` () =
+    let msg = "bad argument"
+    let json = sprintf """{"errorKind":"InvalidArgs","message":%s}""" (serialize msg)
+    Assert.Contains("\"errorKind\":\"InvalidArgs\"", json)
+    Assert.Contains("bad argument", json)
+
+[<Fact>]
+let ``ToolError NotReady serializes with correct errorKind`` () =
+    let msg = "not loaded"
+    let json = sprintf """{"errorKind":"NotReady","message":%s}""" (serialize msg)
+    Assert.Contains("\"errorKind\":\"NotReady\"", json)
+    Assert.Contains("not loaded", json)
+
+[<Fact>]
+let ``ToolError InfraFailure serializes with correct errorKind`` () =
+    let ex = System.Exception("oops")
+    let json = sprintf """{"errorKind":"InfraFailure","message":%s}""" (serialize ex.Message)
+    Assert.Contains("\"errorKind\":\"InfraFailure\"", json)
+    Assert.Contains("oops", json)
+
+[<Fact>]
+let ``ToolError FcsAborted serializes with correct errorKind`` () =
+    let msg = "cancelled"
+    let json = sprintf """{"errorKind":"FcsAborted","message":%s}""" (serialize msg)
+    Assert.Contains("\"errorKind\":\"FcsAborted\"", json)
+    Assert.Contains("cancelled", json)
+
+[<Fact>]
+let ``ToolError FileNotFound serializes with correct errorKind`` () =
+    let msg = "/some/path"
+    let json = sprintf """{"errorKind":"FileNotFound","message":%s}""" (serialize msg)
+    Assert.Contains("\"errorKind\":\"FileNotFound\"", json)
+    Assert.Contains("/some/path", json)
+
+[<Fact>]
+let ``ToolError message with quotes is properly escaped`` () =
+    let msg = "message with \"quotes\""
+    let json = sprintf """{"errorKind":"InvalidArgs","message":%s}""" (serialize msg)
+    Assert.Contains("\"errorKind\":\"InvalidArgs\"", json)
+    // Newtonsoft.Json should escape the inner quotes
+    Assert.Contains("\\\"quotes\\\"", json)
 
 // Helpers
 

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Service" Version="43.12.201" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Closes #20

## What

Introduces a `ToolError` discriminated union for all tool error paths:

```fsharp
type ToolError =
    | InvalidArgs   of string
    | NotReady      of string
    | InfraFailure  of exn
    | FcsAborted    of string
    | FileNotFound  of string
```

`toolResult` now maps exceptions to typed `ToolError` cases instead of all going to `McpError.TransportError`. Every error response includes an `"errorKind"` field so callers can distinguish retryable failures from caller bugs.

## Why

Previously, `ArgumentException`, `OperationCanceledException`, and `IOException` all looked identical to the AI caller. With `errorKind`, callers can retry on `NotReady`/`InfraFailure` and surface `InvalidArgs`/`FileNotFound` as user-facing issues.

## Notes

- `{"status":"not_ready"}` direct-return paths via `NotReadyResponse()` are unchanged
- `NotReady` exception guard is defensive for future external-process raises (documented with comment)
- Test isolation is shallow (tests replicate format string) due to Exe/test-project separation

## Verification

- Build: 0 errors
- Tests: 9/9 pass (3 existing FCS + 6 new ToolError serialization/escaping)
- Integration: SimpleLib ✓, MultiProject ✓