### PR TITLE
test: extract BoundedCache to shared file and add unit tests (#31)

### DIFF
--- a/BoundedCache.fs
+++ b/BoundedCache.fs
@@ -1,0 +1,28 @@
+module FsLangMcp.BoundedCache
+
+/// Thread-safe FIFO-eviction bounded cache.
+/// When maxSize is reached, the oldest inserted key is evicted.
+type internal BoundedCache<'K, 'V when 'K : equality>(maxSize: int) =
+    let dict = System.Collections.Generic.Dictionary<'K, 'V>()
+    let order = System.Collections.Generic.Queue<'K>()
+    let lockObj = obj()
+
+    member _.TryGet(key: 'K) : 'V option =
+        lock lockObj (fun () ->
+            match dict.TryGetValue(key) with
+            | true, v -> Some v
+            | _ -> None)
+
+    member _.Set(key: 'K, value: 'V) =
+        lock lockObj (fun () ->
+            if not (dict.ContainsKey(key)) then
+                if dict.Count >= maxSize then
+                    let oldest = order.Dequeue()
+                    dict.Remove(oldest) |> ignore
+                order.Enqueue(key)
+            dict[key] <- value)
+
+    member _.Clear() =
+        lock lockObj (fun () ->
+            dict.Clear()
+            order.Clear())

--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="BoundedCache.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/Program.fs
+++ b/Program.fs
@@ -17,6 +17,7 @@ open Newtonsoft.Json.Linq
 open StreamJsonRpc
 open Ionide.ProjInfo
 open Ionide.ProjInfo.Types
+open FsLangMcp.BoundedCache
 
 // ─── Shared arg types ──────────────────────────────────────────────────────────
 
@@ -734,33 +735,6 @@ type private FsAutoCompleteBridge() =
         member this.Dispose() =
             this.StopLspUnsafe()
             gate.Dispose()
-
-// ─── BoundedCache ──────────────────────────────────────────────────────────────
-
-type private BoundedCache<'K, 'V when 'K : equality>(maxSize: int) =
-    let dict = System.Collections.Generic.Dictionary<'K, 'V>()
-    let order = System.Collections.Generic.Queue<'K>()
-    let lockObj = obj()
-
-    member _.TryGet(key: 'K) : 'V option =
-        lock lockObj (fun () ->
-            match dict.TryGetValue(key) with
-            | true, v -> Some v
-            | _ -> None)
-
-    member _.Set(key: 'K, value: 'V) =
-        lock lockObj (fun () ->
-            if not (dict.ContainsKey(key)) then
-                if dict.Count >= maxSize then
-                    let oldest = order.Dequeue()
-                    dict.Remove(oldest) |> ignore
-                order.Enqueue(key)
-            dict[key] <- value)
-
-    member _.Clear() =
-        lock lockObj (fun () ->
-            dict.Clear()
-            order.Clear())
 
 // ─── FcsBridge ─────────────────────────────────────────────────────────────────
 

--- a/tests/FsLangMcp.Tests/BoundedCacheTests.fs
+++ b/tests/FsLangMcp.Tests/BoundedCacheTests.fs
@@ -1,0 +1,66 @@
+module FsLangMcp.Tests.BoundedCacheTests
+
+open FsLangMcp.BoundedCache
+open Xunit
+open System.Threading.Tasks
+
+[<Fact>]
+let ``TryGet on empty cache returns None`` () =
+    let cache = BoundedCache<string, int>(3)
+    Assert.Equal(None, cache.TryGet("x"))
+
+[<Fact>]
+let ``Set and TryGet round-trips value`` () =
+    let cache = BoundedCache<string, int>(3)
+    cache.Set("a", 1)
+    Assert.Equal(Some 1, cache.TryGet("a"))
+
+[<Fact>]
+let ``FIFO eviction at capacity`` () =
+    let cache = BoundedCache<string, int>(2)
+    cache.Set("a", 1)
+    cache.Set("b", 2)
+    cache.Set("c", 3)   // evicts "a"
+    Assert.Equal(None,   cache.TryGet("a"))
+    Assert.Equal(Some 2, cache.TryGet("b"))
+    Assert.Equal(Some 3, cache.TryGet("c"))
+
+[<Fact>]
+let ``Update existing key preserves value`` () =
+    let cache = BoundedCache<string, int>(3)
+    cache.Set("a", 1)
+    cache.Set("a", 99)
+    Assert.Equal(Some 99, cache.TryGet("a"))
+
+[<Fact>]
+let ``Clear empties the cache`` () =
+    let cache = BoundedCache<string, int>(3)
+    cache.Set("a", 1)
+    cache.Set("b", 2)
+    cache.Clear()
+    Assert.Equal(None, cache.TryGet("a"))
+    Assert.Equal(None, cache.TryGet("b"))
+
+[<Fact>]
+let ``Capacity-1 cache evicts on each new key`` () =
+    let cache = BoundedCache<int, string>(1)
+    cache.Set(1, "one")
+    cache.Set(2, "two")
+    Assert.Equal(None,        cache.TryGet(1))
+    Assert.Equal(Some "two",  cache.TryGet(2))
+
+[<Fact>]
+let ``Concurrent Set and TryGet does not throw`` () : Task =
+    task {
+        let cache = BoundedCache<int, int>(50)
+        let writers =
+            Array.init 10 (fun i ->
+                Task.Run(fun () ->
+                    for j in 0 .. 99 do cache.Set(i * 100 + j, j)))
+        let readers =
+            Array.init 5 (fun _ ->
+                Task.Run(fun () ->
+                    for k in 0 .. 499 do cache.TryGet(k) |> ignore))
+        do! Task.WhenAll(Array.append writers readers)
+        // No exception = pass
+    }

--- a/tests/FsLangMcp.Tests/BoundedCacheTests.fs
+++ b/tests/FsLangMcp.Tests/BoundedCacheTests.fs
@@ -33,6 +33,18 @@ let ``Update existing key preserves value`` () =
     Assert.Equal(Some 99, cache.TryGet("a"))
 
 [<Fact>]
+let ``Update existing key preserves original eviction order`` () =
+    // capacity 2: a→b inserted, a updated, then c inserted → evicts a (oldest insertion)
+    let cache = BoundedCache<string, int>(2)
+    cache.Set("a", 1)
+    cache.Set("b", 2)
+    cache.Set("a", 99)   // update value; eviction order must NOT change
+    cache.Set("c", 3)    // triggers eviction — must evict "a", not "b"
+    Assert.Equal(None,   cache.TryGet("a"))   // evicted (was oldest)
+    Assert.Equal(Some 2, cache.TryGet("b"))   // retained
+    Assert.Equal(Some 3, cache.TryGet("c"))   // just inserted
+
+[<Fact>]
 let ``Clear empties the cache`` () =
     let cache = BoundedCache<string, int>(3)
     cache.Set("a", 1)

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../../BoundedCache.fs" Link="BoundedCache.fs" />
+    <Compile Include="BoundedCacheTests.fs" />
     <Compile Include="FcsBridgeTests.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #31

## What

Extracted `BoundedCache<'K,'V>` from `Program.fs` into a shared `BoundedCache.fs` file, enabling direct testing. Added 8 unit tests covering all key behavioral invariants.

## Changes

- `BoundedCache.fs` (new) — extracted type as `internal` in `FsLangMcp.BoundedCache` module
- `FsLangMcp.fsproj` — compile `BoundedCache.fs` before `Program.fs`
- `Program.fs` — removed original `type private BoundedCache`, added `open FsLangMcp.BoundedCache`
- `tests/.../FsLangMcp.Tests.fsproj` — linked `../../BoundedCache.fs` + added `BoundedCacheTests.fs`
- `tests/.../BoundedCacheTests.fs` (new) — 8 tests

## Tests

| Test | Covers |
|---|---|
| TryGet on empty → None | baseline |
| Set + TryGet round-trip | basic store/retrieve |
| FIFO eviction at capacity | bounded memory |
| Update in-place preserves value | correct update |
| Update preserves eviction order | FIFO invariant on update |
| Clear empties cache | Clear correctness |
| Capacity-1 evicts on each new key | edge case |
| Concurrent Set + TryGet | thread safety (smoke) |

## Verification

- Build: 0 errors
- Tests: 11/11 pass
- Integration: SimpleLib ✓, MultiProject ✓