### PR TITLE
feat: add fcs_get_project_options tool wrapping proj-info (#27)

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -106,6 +106,9 @@ type RenameArgs =
       newName: string
       text: string option }
 
+[<CLIMutable>]
+type FcsGetProjectOptionsArgs = { projectPath: string }
+
 // ─── Helper: find nearest .fsproj ──────────────────────────────────────────────
 
 let private findNearestFsproj (filePath: string) : string option =
@@ -1527,6 +1530,57 @@ let main argv =
                         "textDocument_rename"
                         "Renames a symbol at a position via fsautocomplete. line/character are 0-based. Requires set_project to be called first (or --project at startup). Pass 'text' to analyze unsaved source content without writing to disk."
                         (fun args -> toolResult (bridge.Rename args))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<FcsGetProjectOptionsArgs>
+                        "fcs_get_project_options"
+                        "Get FSharp compiler project options (OtherOptions) for a .fsproj file using proj-info. Returns the options list to use as `projectOptions` in FCS tools."
+                        (fun args ->
+                            toolResult (task {
+                                let path = args.projectPath
+                                if String.IsNullOrWhiteSpace(path) then
+                                    raise (ArgumentException "projectPath is required")
+
+                                let psi = ProcessStartInfo()
+                                psi.FileName <- "proj-info"
+                                psi.UseShellExecute <- false
+                                psi.RedirectStandardOutput <- true
+                                psi.RedirectStandardError <- true
+                                psi.CreateNoWindow <- true
+                                psi.ArgumentList.Add("--project")
+                                psi.ArgumentList.Add(path)
+                                psi.ArgumentList.Add("--fcs")
+                                psi.ArgumentList.Add("--serialize")
+
+                                use proc = new Process(StartInfo = psi)
+                                if not (proc.Start()) then
+                                    raise (InvalidOperationException "Unable to start proj-info process")
+
+                                let stdout = proc.StandardOutput.ReadToEnd()
+                                let stderr = proc.StandardError.ReadToEnd()
+                                proc.WaitForExit()
+
+                                if proc.ExitCode <> 0 then
+                                    return JObject(
+                                        JProperty("error", $"proj-info failed (exit {proc.ExitCode})"),
+                                        JProperty("stderr", stderr)
+                                    ) :> JToken
+                                else
+                                    let json = JObject.Parse(stdout)
+                                    let otherOptions =
+                                        json["OtherOptions"]
+                                        |> Option.ofObj
+                                        |> Option.map (fun t -> t.ToObject<string[]>())
+                                        |> Option.defaultValue [||]
+
+                                    return JObject(
+                                        JProperty("projectPath", path),
+                                        JProperty("otherOptions", JArray(otherOptions)),
+                                        JProperty("optionsCount", otherOptions.Length)
+                                    ) :> JToken
+                            }))
                     |> unwrapResult
                 )
 

--- a/Program.fs
+++ b/Program.fs
@@ -1578,10 +1578,16 @@ let main argv =
                                     ) :> JToken
                                 else
                                     // proj-info --fcs --serialize outputs a JSON array; take first element
+                                    if String.IsNullOrWhiteSpace(stdout) then
+                                        return JObject(JProperty("error", "proj-info produced no output")) :> JToken
+                                    else
                                     let token = JToken.Parse(stdout)
                                     let json =
                                         match token with
-                                        | :? JArray as arr when arr.Count > 0 -> arr.[0] :?> JObject
+                                        | :? JArray as arr when arr.Count > 0 ->
+                                            match arr.[0] with
+                                            | :? JObject as obj -> obj
+                                            | other -> JObject(JProperty("warning", sprintf "unexpected element type: %s" (other.Type.ToString())))
                                         | :? JObject as obj -> obj
                                         | _ -> JObject()
                                     let otherOptions =

--- a/Program.fs
+++ b/Program.fs
@@ -1329,6 +1329,66 @@ let private runProcess (fileName: string) (args: string list) =
     proc.WaitForExit()
     proc.ExitCode, stdout, stderr
 
+let private parseProjInfoOutput (path: string) (exitCode: int) (stdout: string) (stderr: string) : JToken =
+    if exitCode <> 0 then
+        JObject(
+            JProperty("error", $"proj-info failed (exit {exitCode})"),
+            JProperty("stderr", stderr)
+        ) :> JToken
+    elif String.IsNullOrWhiteSpace(stdout) then
+        JObject(JProperty("error", "proj-info produced no output")) :> JToken
+    else
+        let token = JToken.Parse(stdout)
+        let json =
+            match token with
+            | :? JArray as arr when arr.Count > 0 ->
+                match arr.[0] with
+                | :? JObject as obj -> obj
+                | other -> JObject(JProperty("warning", sprintf "unexpected element type: %s" (other.Type.ToString())))
+            | :? JObject as obj -> obj
+            | _ -> JObject()
+        let otherOptions =
+            json["OtherOptions"]
+            |> Option.ofObj
+            |> Option.map (fun t -> t.ToObject<string[]>())
+            |> Option.defaultValue [||]
+        JObject(
+            JProperty("projectPath", path),
+            JProperty("otherOptions", JArray(otherOptions)),
+            JProperty("optionsCount", otherOptions.Length)
+        ) :> JToken
+
+let private runProjInfoAsync (path: string) : Task<JToken> = task {
+    let psi = ProcessStartInfo()
+    psi.FileName <- "proj-info"
+    psi.UseShellExecute <- false
+    psi.RedirectStandardOutput <- true
+    psi.RedirectStandardError <- true
+    psi.CreateNoWindow <- true
+    psi.ArgumentList.Add("--project")
+    psi.ArgumentList.Add(path)
+    psi.ArgumentList.Add("--fcs")
+    psi.ArgumentList.Add("--serialize")
+
+    use proc = new Process(StartInfo = psi)
+    let started =
+        try
+            proc.Start()
+        with
+        | :? System.ComponentModel.Win32Exception
+        | :? System.IO.IOException ->
+            raise (FileNotFoundException "proj-info not found on PATH. Install with: dotnet tool install -g ionide.projinfo.tool")
+    if not started then
+        raise (InvalidOperationException "Unable to start proj-info process")
+
+    let stdoutTask = proc.StandardOutput.ReadToEndAsync()
+    let stderrTask  = proc.StandardError.ReadToEndAsync()
+    let! stdout = stdoutTask
+    let! stderr = stderrTask
+    do! proc.WaitForExitAsync()
+    return parseProjInfoOutput path proc.ExitCode stdout stderr
+}
+
 let private ensureDotnetGlobalTool (toolId: string) =
     let updateCode, _, updateErr = runProcess "dotnet" [ "tool"; "update"; "-g"; toolId ]
 
@@ -1538,70 +1598,11 @@ let main argv =
                         "fcs_get_project_options"
                         "Get FSharp compiler project options (OtherOptions) for a .fsproj file using proj-info. Returns the options list to use as `projectOptions` in FCS tools."
                         (fun args ->
-                            toolResult (task {
-                                let path = args.projectPath
-                                if String.IsNullOrWhiteSpace(path) then
-                                    raise (ArgumentException "projectPath is required")
-
-                                let psi = ProcessStartInfo()
-                                psi.FileName <- "proj-info"
-                                psi.UseShellExecute <- false
-                                psi.RedirectStandardOutput <- true
-                                psi.RedirectStandardError <- true
-                                psi.CreateNoWindow <- true
-                                psi.ArgumentList.Add("--project")
-                                psi.ArgumentList.Add(path)
-                                psi.ArgumentList.Add("--fcs")
-                                psi.ArgumentList.Add("--serialize")
-
-                                use proc = new Process(StartInfo = psi)
-                                let started =
-                                    try
-                                        proc.Start()
-                                    with
-                                    | :? System.ComponentModel.Win32Exception
-                                    | :? System.IO.IOException ->
-                                        raise (FileNotFoundException "proj-info not found on PATH. Install with: dotnet tool install -g ionide.projinfo.tool")
-                                if not started then
-                                    raise (InvalidOperationException "Unable to start proj-info process")
-
-                                let stdoutTask = proc.StandardOutput.ReadToEndAsync()
-                                let stderrTask  = proc.StandardError.ReadToEndAsync()
-                                let! stdout = stdoutTask
-                                let! stderr = stderrTask
-                                do! proc.WaitForExitAsync()
-
-                                if proc.ExitCode <> 0 then
-                                    return JObject(
-                                        JProperty("error", $"proj-info failed (exit {proc.ExitCode})"),
-                                        JProperty("stderr", stderr)
-                                    ) :> JToken
-                                else
-                                    // proj-info --fcs --serialize outputs a JSON array; take first element
-                                    if String.IsNullOrWhiteSpace(stdout) then
-                                        return JObject(JProperty("error", "proj-info produced no output")) :> JToken
-                                    else
-                                    let token = JToken.Parse(stdout)
-                                    let json =
-                                        match token with
-                                        | :? JArray as arr when arr.Count > 0 ->
-                                            match arr.[0] with
-                                            | :? JObject as obj -> obj
-                                            | other -> JObject(JProperty("warning", sprintf "unexpected element type: %s" (other.Type.ToString())))
-                                        | :? JObject as obj -> obj
-                                        | _ -> JObject()
-                                    let otherOptions =
-                                        json["OtherOptions"]
-                                        |> Option.ofObj
-                                        |> Option.map (fun t -> t.ToObject<string[]>())
-                                        |> Option.defaultValue [||]
-
-                                    return JObject(
-                                        JProperty("projectPath", path),
-                                        JProperty("otherOptions", JArray(otherOptions)),
-                                        JProperty("optionsCount", otherOptions.Length)
-                                    ) :> JToken
-                            }))
+                            let path = args.projectPath
+                            if String.IsNullOrWhiteSpace(path) then
+                                toolResult (Task.FromException<JToken>(ArgumentException "projectPath is required"))
+                            else
+                                toolResult (runProjInfoAsync path))
                     |> unwrapResult
                 )
 

--- a/Program.fs
+++ b/Program.fs
@@ -1555,12 +1555,21 @@ let main argv =
                                 psi.ArgumentList.Add("--serialize")
 
                                 use proc = new Process(StartInfo = psi)
-                                if not (proc.Start()) then
+                                let started =
+                                    try
+                                        proc.Start()
+                                    with
+                                    | :? System.ComponentModel.Win32Exception
+                                    | :? System.IO.IOException ->
+                                        raise (FileNotFoundException "proj-info not found on PATH. Install with: dotnet tool install -g ionide.projinfo.tool")
+                                if not started then
                                     raise (InvalidOperationException "Unable to start proj-info process")
 
-                                let stdout = proc.StandardOutput.ReadToEnd()
-                                let stderr = proc.StandardError.ReadToEnd()
-                                proc.WaitForExit()
+                                let stdoutTask = proc.StandardOutput.ReadToEndAsync()
+                                let stderrTask  = proc.StandardError.ReadToEndAsync()
+                                let! stdout = stdoutTask
+                                let! stderr = stderrTask
+                                do! proc.WaitForExitAsync()
 
                                 if proc.ExitCode <> 0 then
                                     return JObject(
@@ -1568,7 +1577,13 @@ let main argv =
                                         JProperty("stderr", stderr)
                                     ) :> JToken
                                 else
-                                    let json = JObject.Parse(stdout)
+                                    // proj-info --fcs --serialize outputs a JSON array; take first element
+                                    let token = JToken.Parse(stdout)
+                                    let json =
+                                        match token with
+                                        | :? JArray as arr when arr.Count > 0 -> arr.[0] :?> JObject
+                                        | :? JObject as obj -> obj
+                                        | _ -> JObject()
                                     let otherOptions =
                                         json["OtherOptions"]
                                         |> Option.ofObj

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ LSP positions (`line`, `character`) are **0-based**.
 - `fcs_project_symbol_uses`
 - `fcs_type_at_position` — inferred F# type and symbol info at cursor (works without LSP workspace)
 - `fcs_signature_help` — method overloads and parameter info at cursor
+- `fcs_get_project_options` — get `OtherOptions` for a `.fsproj` via `proj-info`; use the result as `projectOptions` in other FCS tools
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,18 @@ LSP positions (`line`, `character`) are **0-based**.
 
 - .NET SDK 10+
 - `fsautocomplete` installed
+- `ionide.projinfo.tool` (required for `fcs_get_project_options`)
 
 Install `fsautocomplete`:
 
 ```bash
 dotnet tool install -g fsautocomplete
+```
+
+Install `ionide.projinfo.tool`:
+
+```bash
+dotnet tool install -g ionide.projinfo.tool
 ```
 
 ## Install As Dotnet Tool


### PR DESCRIPTION
Closes #27

## What

New MCP tool `fcs_get_project_options` that calls `proj-info --fcs --serialize` and returns compiler flags directly. AI callers can now get accurate `projectOptions` for FCS tools without running external commands manually.

## Usage

```json
{"name":"fcs_get_project_options","arguments":{"projectPath":"/absolute/path/App.fsproj"}}
```

Returns:
```json
{"projectPath":"...","otherOptions":["-o:...","--target:library",...],"optionsCount":202}
```

Pass `otherOptions` as `projectOptions` to `fcs_parse_and_check_file`, `fcs_file_symbols`, `fcs_project_symbol_uses`.

## Implementation notes

- `proj-info` output is a JSON array — extracts first element correctly
- stdout/stderr read concurrently (`ReadToEndAsync` + `WaitForExitAsync`) — no deadlock risk
- `Process.Start` wrapped in try/with for `Win32Exception` → clean `FileNotFound` error with install hint
- Empty stdout and unexpected JSON shapes guarded with safe fallbacks
- `ionide.projinfo.tool` added to README Prerequisites

## Verification

- Build: 0 errors
- Tests: 3/3 pass
- Integration: `fcs_get_project_options` returned 202 options for SimpleLib ✓, server PASS ✓ (MultiProject ✓)
- `proj-info` not installed → returns `{"errorKind":"FileNotFound","message":"proj-info not found..."}` (graceful)