### PR TITLE
feat!: wrap all LSP proxy responses in {status,result} envelope (v0.2.0)

### DIFF
--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>FsLangMcp</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fslangmcp</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/Program.fs
+++ b/Program.fs
@@ -356,24 +356,28 @@ type private FsAutoCompleteBridge() =
                 return
                     JObject(
                         JProperty("status", "ok"),
-                        JProperty("projectPath",
-                            capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
-                        JProperty("workspaceRoot", capturedWorkspaceRoot),
-                        JProperty("lspRestarted", restartLsp),
-                        JProperty("solutionMode", isSolution),
-                        JProperty("workspaceLoadStatus", loadStatus)
+                        JProperty("result", JObject(
+                            JProperty("projectPath",
+                                capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
+                            JProperty("workspaceRoot", capturedWorkspaceRoot),
+                            JProperty("lspRestarted", restartLsp),
+                            JProperty("solutionMode", isSolution),
+                            JProperty("workspaceLoadStatus", loadStatus)
+                        ))
                     )
                     :> JToken
             else
                 return
                     JObject(
                         JProperty("status", "ok"),
-                        JProperty("projectPath",
-                            capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
-                        JProperty("workspaceRoot", capturedWorkspaceRoot),
-                        JProperty("lspRestarted", restartLsp),
-                        JProperty("solutionMode", isSolution),
-                        JProperty("workspaceLoadStatus", "not_started")
+                        JProperty("result", JObject(
+                            JProperty("projectPath",
+                                capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
+                            JProperty("workspaceRoot", capturedWorkspaceRoot),
+                            JProperty("lspRestarted", restartLsp),
+                            JProperty("solutionMode", isSolution),
+                            JProperty("workspaceLoadStatus", "not_started")
+                        ))
                     )
                     :> JToken
         }
@@ -544,7 +548,7 @@ type private FsAutoCompleteBridge() =
             // Gate released — StreamJsonRpc handles concurrent requests natively
             let parameters = mkParams uri
             let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>(methodName, parameters)
-            return response
+            return JObject(JProperty("status", "ok"), JProperty("result", response)) :> JToken
         }
 
     member private this.PositionParams(uri: string, line: int, character: int) =
@@ -602,7 +606,7 @@ type private FsAutoCompleteBridge() =
             // No document sync needed — just invoke directly, no gate
             let parameters = jobj [ "query", jstr args.query ]
             let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>("workspace/symbol", parameters)
-            return response
+            return JObject(JProperty("status", "ok"), JProperty("result", response)) :> JToken
         }
 
     member _.Diagnostics(args: DiagnosticsArgs) : Task<JToken> =
@@ -615,14 +619,14 @@ type private FsAutoCompleteBridge() =
             match args.path with
             | Some path ->
                 let uri = toFileUri path
-                return resolveByUri uri
+                return JObject(JProperty("status", "ok"), JProperty("result", resolveByUri uri)) :> JToken
             | None ->
                 let root = JObject()
 
                 for KeyValue(uri, payload) in diagnostics do
                     root[uri] <- payload.DeepClone()
 
-                return root :> JToken
+                return JObject(JProperty("status", "ok"), JProperty("result", root)) :> JToken
         }
 
     member this.Formatting(args: FormattingArgs) : Task<JToken> =
@@ -720,8 +724,10 @@ type private FsAutoCompleteBridge() =
             return
                 JObject(
                     JProperty("status", "ok"),
-                    JProperty("formatted", formatted),
-                    JProperty("edits", if editsToken :? JArray then editsToken else JArray() :> JToken)
+                    JProperty("result", JObject(
+                        JProperty("formatted", formatted),
+                        JProperty("edits", if editsToken :? JArray then editsToken else JArray() :> JToken)
+                    ))
                 )
                 :> JToken
         }
@@ -1187,97 +1193,94 @@ type private FcsBridge() =
         optionsCache.Clear()
         projectResultsCache.Clear()
 
+    member private _.BuildSignatureHelpResult
+        (path: string, source: string, optionsSource: string, args: FcsSignatureHelpArgs, checkedResults: FSharpCheckFileResults option) : JToken =
+        match checkedResults with
+        | None ->
+            JObject(
+                JProperty("status", "aborted"),
+                JProperty("message", "Type checking was aborted.")
+            ) :> JToken
+        | Some checkResults ->
+            // FCS uses 1-based lines; assume input is 0-based (LSP convention)
+            let fcsLine = args.line + 1
+            let fcsCol = args.character
+
+            let lines = source.Split('\n')
+            let lineText =
+                if fcsLine - 1 < lines.Length then lines[fcsLine - 1].TrimEnd('\r')
+                else ""
+
+            let methodsOpt =
+                checkResults.GetMethodsAsSymbols(fcsLine, fcsCol, lineText, [])
+
+            let overloads =
+                match methodsOpt with
+                | None -> [||]
+                | Some symbolUses ->
+                    symbolUses
+                    |> List.choose (fun su ->
+                        match su.Symbol with
+                        | :? FSharpMemberOrFunctionOrValue as m ->
+                            let paramGroups = m.CurriedParameterGroups
+                            let parameters =
+                                paramGroups
+                                |> Seq.collect id
+                                |> Seq.map (fun p ->
+                                    JObject(
+                                        JProperty("name", p.Name |> Option.defaultValue ""),
+                                        JProperty("type", p.Type.BasicQualifiedName)
+                                    )
+                                    :> JToken)
+                                |> Seq.toArray
+
+                            let returnType =
+                                try m.ReturnParameter.Type.BasicQualifiedName
+                                with ex ->
+                                    Console.Error.WriteLine($"[fcs_signature_help] ReturnParameter error: {ex.Message}")
+                                    ""
+
+                            let signature =
+                                let paramStr =
+                                    parameters
+                                    |> Array.map (fun p ->
+                                        let pName = p["name"].Value<string>()
+                                        let pType = p["type"].Value<string>()
+                                        $"{pName}: {pType}")
+                                    |> String.concat ", "
+                                $"{m.DisplayName}({paramStr}) -> {returnType}"
+
+                            Some (JObject(
+                                JProperty("signature", signature),
+                                JProperty("parameters", JArray(parameters)),
+                                JProperty("returnType", returnType)
+                            )
+                            :> JToken)
+                        | _ -> None)
+                    |> List.toArray
+
+            if overloads.Length = 0 then
+                JObject(
+                    JProperty("status", "no_overloads"),
+                    JProperty("file", path),
+                    JProperty("line", args.line),
+                    JProperty("character", args.character)
+                ) :> JToken
+            else
+                JObject(
+                    JProperty("status", "ok"),
+                    JProperty("file", path),
+                    JProperty("line", args.line),
+                    JProperty("character", args.character),
+                    JProperty("optionsSource", optionsSource),
+                    JProperty("overloads", JArray(overloads))
+                ) :> JToken
+
     member this.SignatureHelp(args: FcsSignatureHelpArgs) : Task<JToken> =
         task {
             let! path, source, optionsSource, _, _, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
-
-            match checkedResults with
-            | None ->
-                return
-                    JObject(
-                        JProperty("status", "aborted"),
-                        JProperty("message", "Type checking was aborted.")
-                    )
-                    :> JToken
-            | Some checkResults ->
-                // FCS uses 1-based lines; assume input is 0-based (LSP convention)
-                let fcsLine = args.line + 1
-                let fcsCol = args.character
-
-                let lines = source.Split('\n')
-                let lineText =
-                    if fcsLine - 1 < lines.Length then lines[fcsLine - 1].TrimEnd('\r')
-                    else ""
-
-                let methodsOpt =
-                    checkResults.GetMethodsAsSymbols(fcsLine, fcsCol, lineText, [])
-
-                let overloads =
-                    match methodsOpt with
-                    | None -> [||]
-                    | Some symbolUses ->
-                        symbolUses
-                        |> List.choose (fun su ->
-                            match su.Symbol with
-                            | :? FSharpMemberOrFunctionOrValue as m ->
-                                let paramGroups = m.CurriedParameterGroups
-                                let parameters =
-                                    paramGroups
-                                    |> Seq.collect id
-                                    |> Seq.map (fun p ->
-                                        JObject(
-                                            JProperty("name", p.Name |> Option.defaultValue ""),
-                                            JProperty("type", p.Type.BasicQualifiedName)
-                                        )
-                                        :> JToken)
-                                    |> Seq.toArray
-
-                                let returnType =
-                                    try m.ReturnParameter.Type.BasicQualifiedName
-                                    with ex ->
-                                        Console.Error.WriteLine($"[fcs_signature_help] ReturnParameter error: {ex.Message}")
-                                        ""
-
-                                let signature =
-                                    let paramStr =
-                                        parameters
-                                        |> Array.map (fun p ->
-                                            let pName = p["name"].Value<string>()
-                                            let pType = p["type"].Value<string>()
-                                            $"{pName}: {pType}")
-                                        |> String.concat ", "
-                                    $"{m.DisplayName}({paramStr}) -> {returnType}"
-
-                                Some (JObject(
-                                    JProperty("signature", signature),
-                                    JProperty("parameters", JArray(parameters)),
-                                    JProperty("returnType", returnType)
-                                )
-                                :> JToken)
-                            | _ -> None)
-                        |> List.toArray
-
-                if overloads.Length = 0 then
-                    return
-                        JObject(
-                            JProperty("status", "no_overloads"),
-                            JProperty("file", path),
-                            JProperty("line", args.line),
-                            JProperty("character", args.character)
-                        )
-                        :> JToken
-                else
-                    return
-                        JObject(
-                            JProperty("status", "ok"),
-                            JProperty("file", path),
-                            JProperty("line", args.line),
-                            JProperty("character", args.character),
-                            JProperty("optionsSource", optionsSource),
-                            JProperty("overloads", JArray(overloads))
-                        )
-                        :> JToken
+            return this.BuildSignatureHelpResult(path, source, optionsSource, args, checkedResults)
         }
 
 // ─── MCP helpers ───────────────────────────────────────────────────────────────

--- a/Program.fs
+++ b/Program.fs
@@ -1482,7 +1482,7 @@ let main argv =
         let server =
             mcpServer {
                 name "fsharp-fsautocomplete"
-                version "0.1.0"
+                version "0.2.0"
 
                 tool (
                     TypedTool.define<CompletionArgs>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ An MCP server written in F# that combines:
 
 > Work in progress: APIs and tool shapes may still change.
 
+## Response Shape
+
+All tools return a consistent JSON envelope:
+
+- **Success**: `{"status": "ok", "result": <payload>}` (LSP tools) or `{"status": "ok", ...fields}` (FCS tools)
+- **Not ready**: `{"status": "not_ready", "message": "..."}` — LSP workspace still loading
+- **Error**: MCP protocol error with `{"errorKind": "...", "message": "..."}` payload
+
 ## What You Get
 
 ### LSP-proxy tools (via `fsautocomplete`)


### PR DESCRIPTION
Closes #26

## Summary
- All LSP proxy tools (`textDocument_hover`, `textDocument_definition`, `textDocument_completion`, `textDocument_references`, `textDocument_formatting`, `textDocument_codeAction`, `textDocument_rename`, `workspace_symbol`, `workspace_diagnostics`, `set_project`) now return a consistent `{"status": "ok", "result": <payload>}` envelope
- Callers no longer need two different parsing strategies — FCS tools and LSP tools now use the same shape
- Error/not-ready responses stay as `{"status": "not_ready", "message": "..."}` (no change)
- Extracted `SignatureHelp` sync body into `BuildSignatureHelpResult` to eliminate FS3511 warning — 0 warnings total
- Bumped version to **0.2.0** (breaking change)

## Test plan
- [ ] `dotnet build --configuration Release` — 0 errors, 0 warnings
- [ ] `dotnet test --configuration Release` — 17/17 pass
- [ ] Smoke-test `textDocument_hover` response shape: confirm `{"status":"ok","result":{...}}`
- [ ] Confirm `set_project` response: `{"status":"ok","result":{"projectPath":...,"workspaceLoadStatus":"ready"}}`