### PR TITLE
test: link Types.fs + Tools.fs into test project for real toolErrorToJson coverage (closes #41)

### DIFF
--- a/tests/FsLangMcp.Tests/FcsBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/FcsBridgeTests.fs
@@ -6,54 +6,48 @@ open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Text
-open Newtonsoft.Json
 open Xunit
+open FsLangMcp.Types
+open FsLangMcp.Tools
 
 // ─── ToolError serialization tests ────────────────────────────────────────────
-// These tests replicate the serialization pattern from Program.fs inline,
-// providing regression coverage without requiring a reference to the Exe project.
-
-let private serialize (msg: string) = JsonConvert.SerializeObject msg
+// These tests call the real toolErrorToJson from Tools.fs so that regressions
+// in the serialization logic are caught directly.
 
 [<Fact>]
 let ``ToolError InvalidArgs serializes with correct errorKind and message`` () =
-    let msg = "bad argument"
-    let json = sprintf """{"errorKind":"InvalidArgs","message":%s}""" (serialize msg)
+    let json = toolErrorToJson (InvalidArgs "bad argument")
     Assert.Contains("\"errorKind\":\"InvalidArgs\"", json)
     Assert.Contains("bad argument", json)
 
 [<Fact>]
 let ``ToolError NotReady serializes with correct errorKind`` () =
-    let msg = "not loaded"
-    let json = sprintf """{"errorKind":"NotReady","message":%s}""" (serialize msg)
+    let json = toolErrorToJson (NotReady "not loaded")
     Assert.Contains("\"errorKind\":\"NotReady\"", json)
     Assert.Contains("not loaded", json)
 
 [<Fact>]
 let ``ToolError InfraFailure serializes with correct errorKind`` () =
-    let ex = System.Exception("oops")
-    let json = sprintf """{"errorKind":"InfraFailure","message":%s}""" (serialize ex.Message)
+    let ex = Exception("oops")
+    let json = toolErrorToJson (InfraFailure ex)
     Assert.Contains("\"errorKind\":\"InfraFailure\"", json)
     Assert.Contains("oops", json)
 
 [<Fact>]
 let ``ToolError FcsAborted serializes with correct errorKind`` () =
-    let msg = "cancelled"
-    let json = sprintf """{"errorKind":"FcsAborted","message":%s}""" (serialize msg)
+    let json = toolErrorToJson (FcsAborted "cancelled")
     Assert.Contains("\"errorKind\":\"FcsAborted\"", json)
     Assert.Contains("cancelled", json)
 
 [<Fact>]
 let ``ToolError FileNotFound serializes with correct errorKind`` () =
-    let msg = "/some/path"
-    let json = sprintf """{"errorKind":"FileNotFound","message":%s}""" (serialize msg)
+    let json = toolErrorToJson (FileNotFound "/some/path")
     Assert.Contains("\"errorKind\":\"FileNotFound\"", json)
     Assert.Contains("/some/path", json)
 
 [<Fact>]
 let ``ToolError message with quotes is properly escaped`` () =
-    let msg = "message with \"quotes\""
-    let json = sprintf """{"errorKind":"InvalidArgs","message":%s}""" (serialize msg)
+    let json = toolErrorToJson (InvalidArgs "message with \"quotes\"")
     Assert.Contains("\"errorKind\":\"InvalidArgs\"", json)
     // Newtonsoft.Json should escape the inner quotes
     Assert.Contains("\\\"quotes\\\"", json)

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -8,12 +8,15 @@
 
   <ItemGroup>
     <Compile Include="../../BoundedCache.fs" Link="BoundedCache.fs" />
+    <Compile Include="../../Types.fs" Link="Types.fs" />
+    <Compile Include="../../Tools.fs" Link="Tools.fs" />
     <Compile Include="BoundedCacheTests.fs" />
     <Compile Include="FcsBridgeTests.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Service" Version="43.12.201" />
+    <PackageReference Include="FsMcp.Server" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
Closes #41

## Summary
- Adds `../../Types.fs` and `../../Tools.fs` source file links to `tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj` (same pattern as existing `BoundedCache.fs` link)
- Adds `FsMcp.Server` package reference (needed by Tools.fs for Content/McpError types)
- Updates `FcsBridgeTests.fs`: removes inline `serialize` helper and pattern-replicated JSON strings; 6 ToolError tests now call `FsLangMcp.Tools.toolErrorToJson` directly with actual DU constructors
- Compile order: BoundedCache.fs → Types.fs → Tools.fs → test files

## Before
Tests replicated the `toolErrorToJson` serialization format inline — a regression in `Tools.fs` would NOT be caught.

## After
Tests call the real function — regressions in `toolErrorToJson` will fail the test suite.

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors, 0 warnings
- [x] `dotnet test` — 17/17 pass (including 6 ToolError tests now calling real function)
- [x] Code review: APPROVED
- [x] Reality check: APPROVED