### PR TITLE
feat: migrate from Newtonsoft.Json to System.Text.Json (closes #13)

### DIFF
--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -11,7 +11,8 @@ open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
 open FSharp.Compiler.EditorServices
-open Newtonsoft.Json.Linq
+open System.Text.Json
+open System.Text.Json.Nodes
 open Ionide.ProjInfo
 open Ionide.ProjInfo.Types
 
@@ -43,62 +44,58 @@ type internal FcsBridge() =
     let asTask (workflow: Async<'T>) : Task<'T> =
         Async.StartAsTask(workflow, cancellationToken = CancellationToken.None)
 
-    let jstrOrNull (value: string) =
-        if String.IsNullOrWhiteSpace(value) then JValue.CreateNull() :> JToken else JValue(value) :> JToken
+    let jstrOrNull (value: string) : JsonNode =
+        if String.IsNullOrWhiteSpace(value) then null else JsonValue.Create(value)
 
-    let rangeToJson (r: range) =
-        JObject(
-            JProperty("file", normalizePath r.FileName),
-            JProperty("startLine", r.StartLine),
-            JProperty("startColumn", r.StartColumn),
-            JProperty("endLine", r.EndLine),
-            JProperty("endColumn", r.EndColumn)
-        )
-        :> JToken
+    let rangeToJson (r: range) : JsonNode =
+        jobj
+            [ "file", jstr (normalizePath r.FileName)
+              "startLine", jint r.StartLine
+              "startColumn", jint r.StartColumn
+              "endLine", jint r.EndLine
+              "endColumn", jint r.EndColumn ]
+        :> JsonNode
 
-    let positionToJson (p: Position) =
-        JObject(JProperty("line", p.Line), JProperty("column", p.Column)) :> JToken
+    let positionToJson (p: Position) : JsonNode =
+        jobj [ "line", jint p.Line; "column", jint p.Column ] :> JsonNode
 
-    let diagnosticToJson (d: FSharpDiagnostic) =
-        JObject(
-            JProperty("file", normalizePath d.FileName),
-            JProperty("message", d.Message),
-            JProperty("severity", d.Severity.ToString()),
-            JProperty("errorNumber", d.ErrorNumber),
-            JProperty("errorNumberText", d.ErrorNumberText),
-            JProperty("subcategory", d.Subcategory),
-            JProperty("range", rangeToJson d.Range),
-            JProperty("start", positionToJson d.Start),
-            JProperty("end", positionToJson d.End)
-        )
-        :> JToken
+    let diagnosticToJson (d: FSharpDiagnostic) : JsonNode =
+        jobj
+            [ "file", jstr (normalizePath d.FileName)
+              "message", jstr d.Message
+              "severity", jstr (d.Severity.ToString())
+              "errorNumber", jint d.ErrorNumber
+              "errorNumberText", jstr d.ErrorNumberText
+              "subcategory", jstr d.Subcategory
+              "range", rangeToJson d.Range
+              "start", positionToJson d.Start
+              "end", positionToJson d.End ]
+        :> JsonNode
 
-    let symbolToJson (symbol: FSharpSymbol) =
+    let symbolToJson (symbol: FSharpSymbol) : JsonNode =
         let declarationLocation =
             match symbol.DeclarationLocation with
             | Some r -> rangeToJson r
-            | None -> JValue.CreateNull() :> JToken
+            | None -> null
 
-        JObject(
-            JProperty("displayName", symbol.DisplayName),
-            JProperty("fullName", jstrOrNull symbol.FullName),
-            JProperty("assembly", symbol.Assembly.SimpleName),
-            JProperty("declarationLocation", declarationLocation),
-            JProperty("isExplicitlySuppressed", symbol.IsExplicitlySuppressed)
-        )
-        :> JToken
+        jobj
+            [ "displayName", jstr symbol.DisplayName
+              "fullName", jstrOrNull symbol.FullName
+              "assembly", jstr symbol.Assembly.SimpleName
+              "declarationLocation", declarationLocation
+              "isExplicitlySuppressed", jbool symbol.IsExplicitlySuppressed ]
+        :> JsonNode
 
-    let symbolUseToJson (symbolUse: FSharpSymbolUse) =
-        JObject(
-            JProperty("file", normalizePath symbolUse.FileName),
-            JProperty("range", rangeToJson symbolUse.Range),
-            JProperty("isFromDefinition", symbolUse.IsFromDefinition),
-            JProperty("isFromUse", symbolUse.IsFromUse),
-            JProperty("isFromPattern", symbolUse.IsFromPattern),
-            JProperty("isFromAttribute", symbolUse.IsFromAttribute),
-            JProperty("symbol", symbolToJson symbolUse.Symbol)
-        )
-        :> JToken
+    let symbolUseToJson (symbolUse: FSharpSymbolUse) : JsonNode =
+        jobj
+            [ "file", jstr (normalizePath symbolUse.FileName)
+              "range", rangeToJson symbolUse.Range
+              "isFromDefinition", jbool symbolUse.IsFromDefinition
+              "isFromUse", jbool symbolUse.IsFromUse
+              "isFromPattern", jbool symbolUse.IsFromPattern
+              "isFromAttribute", jbool symbolUse.IsFromAttribute
+              "symbol", symbolToJson symbolUse.Symbol ]
+        :> JsonNode
 
     // Build a stable cache key from projectPath and projectOptions list
     let makeCacheKey (projectPath: string option) (projectOptions: string list option) =
@@ -213,7 +210,7 @@ type internal FcsBridge() =
             return fullPath, source, optionsSource, options, parseResults, checkedResults
         }
 
-    member this.ParseAndCheckFile(args: FcsParseAndCheckArgs) : Task<JToken> =
+    member this.ParseAndCheckFile(args: FcsParseAndCheckArgs) : Task<JsonNode> =
         task {
             let! path, _, optionsSource, projectOptions, parseResults, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
@@ -228,21 +225,21 @@ type internal FcsBridge() =
             let status = if checkedResults.IsSome then "succeeded" else "aborted"
 
             return
-                JObject(
-                    JProperty("status", status),
-                    JProperty("file", path),
-                    JProperty("optionsSource", optionsSource),
-                    JProperty("projectFileName", projectOptions.ProjectFileName),
-                    JProperty("projectSourceFiles", JArray(projectOptions.SourceFiles)),
-                    JProperty("parseHadErrors", parseResults.ParseHadErrors),
-                    JProperty("hasFullTypeCheckInfo", hasTypeCheckInfo),
-                    JProperty("parseDiagnostics", JArray(parseDiagnostics)),
-                    JProperty("checkDiagnostics", JArray(checkDiagnostics))
-                )
-                :> JToken
+                jobj
+                    [ "status", jstr status
+                      "file", jstr path
+                      "optionsSource", jstr optionsSource
+                      "projectFileName", jstr projectOptions.ProjectFileName
+                      "projectSourceFiles",
+                      JsonArray(projectOptions.SourceFiles |> Array.map jstr) :> JsonNode
+                      "parseHadErrors", jbool parseResults.ParseHadErrors
+                      "hasFullTypeCheckInfo", jbool hasTypeCheckInfo
+                      "parseDiagnostics", JsonArray(parseDiagnostics) :> JsonNode
+                      "checkDiagnostics", JsonArray(checkDiagnostics) :> JsonNode ]
+                :> JsonNode
         }
 
-    member this.FileSymbols(args: FcsFileSymbolsArgs) : Task<JToken> =
+    member this.FileSymbols(args: FcsFileSymbolsArgs) : Task<JsonNode> =
         task {
             let! path, _, optionsSource, _, parseResults, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
@@ -250,15 +247,15 @@ type internal FcsBridge() =
             match checkedResults with
             | None ->
                 return
-                    JObject(
-                        JProperty("status", "aborted"),
-                        JProperty("file", path),
-                        JProperty("optionsSource", optionsSource),
-                        JProperty("parseHadErrors", parseResults.ParseHadErrors),
-                        JProperty("message", "Type checking was aborted. Symbols are unavailable."),
-                        JProperty("parseDiagnostics", JArray(parseResults.Diagnostics |> Array.map diagnosticToJson))
-                    )
-                    :> JToken
+                    jobj
+                        [ "status", jstr "aborted"
+                          "file", jstr path
+                          "optionsSource", jstr optionsSource
+                          "parseHadErrors", jbool parseResults.ParseHadErrors
+                          "message", jstr "Type checking was aborted. Symbols are unavailable."
+                          "parseDiagnostics",
+                          JsonArray(parseResults.Diagnostics |> Array.map diagnosticToJson) :> JsonNode ]
+                    :> JsonNode
             | Some checkResults ->
                 let includeAllUses = args.includeAllUses |> Option.defaultValue false
                 let maxResults = args.maxResults |> Option.defaultValue 200
@@ -277,20 +274,21 @@ type internal FcsBridge() =
                     |> Seq.toArray
 
                 return
-                    JObject(
-                        JProperty("status", "succeeded"),
-                        JProperty("file", path),
-                        JProperty("optionsSource", optionsSource),
-                        JProperty("includeAllUses", includeAllUses),
-                        JProperty("count", symbols.Length),
-                        JProperty("symbols", JArray(symbols)),
-                        JProperty("parseDiagnostics", JArray(parseResults.Diagnostics |> Array.map diagnosticToJson)),
-                        JProperty("checkDiagnostics", JArray(checkResults.Diagnostics |> Array.map diagnosticToJson))
-                    )
-                    :> JToken
+                    jobj
+                        [ "status", jstr "succeeded"
+                          "file", jstr path
+                          "optionsSource", jstr optionsSource
+                          "includeAllUses", jbool includeAllUses
+                          "count", jint symbols.Length
+                          "symbols", JsonArray(symbols) :> JsonNode
+                          "parseDiagnostics",
+                          JsonArray(parseResults.Diagnostics |> Array.map diagnosticToJson) :> JsonNode
+                          "checkDiagnostics",
+                          JsonArray(checkResults.Diagnostics |> Array.map diagnosticToJson) :> JsonNode ]
+                    :> JsonNode
         }
 
-    member this.ProjectSymbolUses(args: FcsProjectSymbolUsesArgs) : Task<JToken> =
+    member this.ProjectSymbolUses(args: FcsProjectSymbolUsesArgs) : Task<JsonNode> =
         task {
             let query = args.symbolQuery.Trim()
 
@@ -341,22 +339,22 @@ type internal FcsBridge() =
                 |> Seq.toArray
 
             return
-                JObject(
-                    JProperty("status", "succeeded"),
-                    JProperty("optionsSource", optionsSource),
-                    JProperty("projectFileName", projectOptions.ProjectFileName),
-                    JProperty("query", query),
-                    JProperty("exact", exact),
-                    JProperty("cached", cached),
-                    JProperty("totalProjectSymbolUses", allUses.Length),
-                    JProperty("matchedCount", matchedUses.Length),
-                    JProperty("uses", JArray(matchedUses)),
-                    JProperty("projectDiagnostics", JArray(projectResults.Diagnostics |> Array.map diagnosticToJson))
-                )
-                :> JToken
+                jobj
+                    [ "status", jstr "succeeded"
+                      "optionsSource", jstr optionsSource
+                      "projectFileName", jstr projectOptions.ProjectFileName
+                      "query", jstr query
+                      "exact", jbool exact
+                      "cached", jbool cached
+                      "totalProjectSymbolUses", jint allUses.Length
+                      "matchedCount", jint matchedUses.Length
+                      "uses", JsonArray(matchedUses) :> JsonNode
+                      "projectDiagnostics",
+                      JsonArray(projectResults.Diagnostics |> Array.map diagnosticToJson) :> JsonNode ]
+                :> JsonNode
         }
 
-    member this.TypeAtPosition(args: FcsTypeAtPositionArgs) : Task<JToken> =
+    member this.TypeAtPosition(args: FcsTypeAtPositionArgs) : Task<JsonNode> =
         task {
             let! path, source, optionsSource, _, _, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
@@ -364,11 +362,8 @@ type internal FcsBridge() =
             match checkedResults with
             | None ->
                 return
-                    JObject(
-                        JProperty("status", "aborted"),
-                        JProperty("message", "Type checking was aborted.")
-                    )
-                    :> JToken
+                    jobj [ "status", jstr "aborted"; "message", jstr "Type checking was aborted." ]
+                    :> JsonNode
             | Some checkResults ->
                 // FCS uses 1-based lines; assume input is 0-based (LSP convention)
                 let fcsLine = args.line + 1
@@ -424,29 +419,27 @@ type internal FcsBridge() =
                 match symbolUse with
                 | None ->
                     return
-                        JObject(
-                            JProperty("status", "no_symbol"),
-                            JProperty("message", "No symbol at this position"),
-                            JProperty("file", path),
-                            JProperty("line", args.line),
-                            JProperty("character", args.character),
-                            JProperty("typeString", typeString)
-                        )
-                        :> JToken
+                        jobj
+                            [ "status", jstr "no_symbol"
+                              "message", jstr "No symbol at this position"
+                              "file", jstr path
+                              "line", jint args.line
+                              "character", jint args.character
+                              "typeString", jstr typeString ]
+                        :> JsonNode
                 | Some su ->
                     return
-                        JObject(
-                            JProperty("status", "ok"),
-                            JProperty("file", path),
-                            JProperty("line", args.line),
-                            JProperty("character", args.character),
-                            JProperty("optionsSource", optionsSource),
-                            JProperty("symbolName", su.Symbol.DisplayName),
-                            JProperty("fullName", jstrOrNull su.Symbol.FullName),
-                            JProperty("typeString", typeString),
-                            JProperty("xmlDoc", xmlDoc)
-                        )
-                        :> JToken
+                        jobj
+                            [ "status", jstr "ok"
+                              "file", jstr path
+                              "line", jint args.line
+                              "character", jint args.character
+                              "optionsSource", jstr optionsSource
+                              "symbolName", jstr su.Symbol.DisplayName
+                              "fullName", jstrOrNull su.Symbol.FullName
+                              "typeString", jstr typeString
+                              "xmlDoc", jstr xmlDoc ]
+                        :> JsonNode
         }
 
     member _.ClearCaches() =
@@ -455,14 +448,11 @@ type internal FcsBridge() =
 
     member private _.BuildSignatureHelpResult
         (path: string, source: string, optionsSource: string, args: FcsSignatureHelpArgs, checkedResults: FSharpCheckFileResults option)
-        : JToken =
+        : JsonNode =
         match checkedResults with
         | None ->
-            JObject(
-                JProperty("status", "aborted"),
-                JProperty("message", "Type checking was aborted.")
-            )
-            :> JToken
+            jobj [ "status", jstr "aborted"; "message", jstr "Type checking was aborted." ]
+            :> JsonNode
         | Some checkResults ->
             // FCS uses 1-based lines; assume input is 0-based (LSP convention)
             let fcsLine = args.line + 1
@@ -489,11 +479,10 @@ type internal FcsBridge() =
                                 paramGroups
                                 |> Seq.collect id
                                 |> Seq.map (fun p ->
-                                    JObject(
-                                        JProperty("name", p.Name |> Option.defaultValue ""),
-                                        JProperty("type", p.Type.BasicQualifiedName)
-                                    )
-                                    :> JToken)
+                                    jobj
+                                        [ "name", jstr (p.Name |> Option.defaultValue "")
+                                          "type", jstr p.Type.BasicQualifiedName ]
+                                    :> JsonNode)
                                 |> Seq.toArray
 
                             let returnType =
@@ -506,41 +495,38 @@ type internal FcsBridge() =
                                 let paramStr =
                                     parameters
                                     |> Array.map (fun p ->
-                                        let pName = p["name"].Value<string>()
-                                        let pType = p["type"].Value<string>()
+                                        let pName = p["name"].GetValue<string>()
+                                        let pType = p["type"].GetValue<string>()
                                         $"{pName}: {pType}")
                                     |> String.concat ", "
                                 $"{m.DisplayName}({paramStr}) -> {returnType}"
 
-                            Some (JObject(
-                                JProperty("signature", signature),
-                                JProperty("parameters", JArray(parameters)),
-                                JProperty("returnType", returnType)
-                            )
-                            :> JToken)
+                            Some (jobj
+                                [ "signature", jstr signature
+                                  "parameters", JsonArray(parameters) :> JsonNode
+                                  "returnType", jstr returnType ]
+                            :> JsonNode)
                         | _ -> None)
                     |> List.toArray
 
             if overloads.Length = 0 then
-                JObject(
-                    JProperty("status", "no_overloads"),
-                    JProperty("file", path),
-                    JProperty("line", args.line),
-                    JProperty("character", args.character)
-                )
-                :> JToken
+                jobj
+                    [ "status", jstr "no_overloads"
+                      "file", jstr path
+                      "line", jint args.line
+                      "character", jint args.character ]
+                :> JsonNode
             else
-                JObject(
-                    JProperty("status", "ok"),
-                    JProperty("file", path),
-                    JProperty("line", args.line),
-                    JProperty("character", args.character),
-                    JProperty("optionsSource", optionsSource),
-                    JProperty("overloads", JArray(overloads))
-                )
-                :> JToken
+                jobj
+                    [ "status", jstr "ok"
+                      "file", jstr path
+                      "line", jint args.line
+                      "character", jint args.character
+                      "optionsSource", jstr optionsSource
+                      "overloads", JsonArray(overloads) :> JsonNode ]
+                :> JsonNode
 
-    member this.SignatureHelp(args: FcsSignatureHelpArgs) : Task<JToken> =
+    member this.SignatureHelp(args: FcsSignatureHelpArgs) : Task<JsonNode> =
         task {
             let! path, source, optionsSource, _, _, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)

--- a/LspBridge.fs
+++ b/LspBridge.fs
@@ -7,8 +7,9 @@ open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
 open FsLangMcp.Types
-open Newtonsoft.Json
-open Newtonsoft.Json.Linq
+open System.Text.Json
+open System.Text.Json.Nodes
+open System.Text.Json.Serialization
 open StreamJsonRpc
 
 // ─── LSP types ─────────────────────────────────────────────────────────────────
@@ -17,24 +18,24 @@ type private LspDocumentState =
     { mutable Version: int
       mutable Text: string }
 
-type private DiagnosticsTarget(store: ConcurrentDictionary<string, JToken>) =
+type private DiagnosticsTarget(store: ConcurrentDictionary<string, JsonNode>) =
     [<JsonRpcMethod("textDocument/publishDiagnostics")>]
-    member _.PublishDiagnostics(payload: JObject) =
+    member _.PublishDiagnostics(payload: JsonObject) =
         let uriToken = payload["uri"]
 
         if not (isNull uriToken) then
-            let uri = uriToken.Value<string>()
+            let uri = uriToken.GetValue<string>()
             let diagnostics = payload["diagnostics"]
-            store[uri] <- if isNull diagnostics then JArray() :> JToken else diagnostics.DeepClone()
+            store[uri] <- if isNull diagnostics then JsonArray() :> JsonNode else diagnostics.DeepClone()
 
 // ─── WorkspaceLoadTarget: tracks fsharp/workspaceLoad notification ─────────────
 
 type private WorkspaceLoadTarget(setReady: unit -> unit) =
     [<JsonRpcMethod("fsharp/workspaceLoad")>]
-    member _.WorkspaceLoad(payload: JObject) =
+    member _.WorkspaceLoad(payload: JsonObject) =
         let statusToken = payload["status"]
         if not (isNull statusToken) then
-            let status = statusToken.Value<string>()
+            let status = statusToken.GetValue<string>()
             if String.Equals(status, "finished", StringComparison.OrdinalIgnoreCase) then
                 setReady ()
 
@@ -43,7 +44,7 @@ type private WorkspaceLoadTarget(setReady: unit -> unit) =
 type internal FsAutoCompleteBridge() =
     let gate = new SemaphoreSlim(1, 1)
     let documents = ConcurrentDictionary<string, LspDocumentState>()
-    let diagnostics = ConcurrentDictionary<string, JToken>()
+    let diagnostics = ConcurrentDictionary<string, JsonNode>()
     [<VolatileField>]
     let mutable rpc: JsonRpc option = None
     [<VolatileField>]
@@ -144,14 +145,13 @@ type internal FsAutoCompleteBridge() =
         }
 
     // Return not-ready JSON if workspace not loaded yet
-    member _.NotReadyResponse() : JToken =
-        JObject(
-            JProperty("status", "not_ready"),
-            JProperty("message", "fsautocomplete is still loading the project. Try again in a moment.")
-        )
-        :> JToken
+    member _.NotReadyResponse() : JsonNode =
+        jobj
+            [ "status", jstr "not_ready"
+              "message", jstr "fsautocomplete is still loading the project. Try again in a moment." ]
+        :> JsonNode
 
-    member this.SetProject(args: SetProjectArgs) : Task<JToken> =
+    member this.SetProject(args: SetProjectArgs) : Task<JsonNode> =
         task {
             let projectPath = Path.GetFullPath(args.projectPath)
 
@@ -211,32 +211,32 @@ type internal FsAutoCompleteBridge() =
                 let loadStatus = if ready then "ready" else "timeout"
 
                 return
-                    JObject(
-                        JProperty("status", "ok"),
-                        JProperty("result", JObject(
-                            JProperty("projectPath",
-                                capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
-                            JProperty("workspaceRoot", capturedWorkspaceRoot),
-                            JProperty("lspRestarted", restartLsp),
-                            JProperty("solutionMode", isSolution),
-                            JProperty("workspaceLoadStatus", loadStatus)
-                        ))
-                    )
-                    :> JToken
+                    jobj
+                        [ "status", jstr "ok"
+                          "result",
+                          jobj
+                              [ "projectPath",
+                                capturedProjectPath |> Option.map jstr |> Option.defaultValue null
+                                "workspaceRoot", jstr capturedWorkspaceRoot
+                                "lspRestarted", jbool restartLsp
+                                "solutionMode", jbool isSolution
+                                "workspaceLoadStatus", jstr loadStatus ]
+                          :> JsonNode ]
+                    :> JsonNode
             else
                 return
-                    JObject(
-                        JProperty("status", "ok"),
-                        JProperty("result", JObject(
-                            JProperty("projectPath",
-                                capturedProjectPath |> Option.map JValue |> Option.defaultValue (JValue.CreateNull()) :> JToken),
-                            JProperty("workspaceRoot", capturedWorkspaceRoot),
-                            JProperty("lspRestarted", restartLsp),
-                            JProperty("solutionMode", isSolution),
-                            JProperty("workspaceLoadStatus", "not_started")
-                        ))
-                    )
-                    :> JToken
+                    jobj
+                        [ "status", jstr "ok"
+                          "result",
+                          jobj
+                              [ "projectPath",
+                                capturedProjectPath |> Option.map jstr |> Option.defaultValue null
+                                "workspaceRoot", jstr capturedWorkspaceRoot
+                                "lspRestarted", jbool restartLsp
+                                "solutionMode", jbool isSolution
+                                "workspaceLoadStatus", jstr "not_started" ]
+                          :> JsonNode ]
+                    :> JsonNode
         }
 
     // StartLspUnsafe: assumes gate is already held by caller
@@ -288,8 +288,10 @@ type internal FsAutoCompleteBridge() =
 
             stderrPump <- Some pumpStderr
 
-            let formatter = new JsonMessageFormatter()
-            formatter.JsonSerializer.NullValueHandling <- NullValueHandling.Ignore
+            let formatter = new SystemTextJsonFormatter()
+            let formatterOpts = JsonSerializerOptions()
+            formatterOpts.DefaultIgnoreCondition <- JsonIgnoreCondition.WhenWritingNull
+            formatter.JsonSerializerOptions <- formatterOpts
 
             let handler =
                 new HeaderDelimitedMessageHandler(
@@ -315,7 +317,7 @@ type internal FsAutoCompleteBridge() =
                       "trace", jstr "off"
                       "clientInfo", jobj [ "name", jstr "fsmcp-fsharp"; "version", jstr "0.1.0" ]
                       "workspaceFolders",
-                      JArray(jobj [ "uri", jstr rootUri; "name", jstr workspaceName ]) :> JToken
+                      JsonArray(jobj [ "uri", jstr rootUri; "name", jstr workspaceName ] :> JsonNode) :> JsonNode
                       "capabilities",
                       jobj
                           [ "workspace", jobj [ "workspaceFolders", jbool true ]
@@ -324,8 +326,8 @@ type internal FsAutoCompleteBridge() =
                                 [ "completion",
                                   jobj [ "completionItem", jobj [ "snippetSupport", jbool true ] ] ] ] ]
 
-            let! _ = jsonRpc.InvokeWithParameterObjectAsync<JToken>("initialize", initializeParams)
-            do! jsonRpc.NotifyWithParameterObjectAsync("initialized", JObject())
+            let! _ = jsonRpc.InvokeWithParameterObjectAsync<JsonNode>("initialize", initializeParams)
+            do! jsonRpc.NotifyWithParameterObjectAsync("initialized", JsonObject())
 
             rpc <- Some jsonRpc
             lspProcess <- Some fsacProc
@@ -361,7 +363,7 @@ type internal FsAutoCompleteBridge() =
                 let didChangeParams =
                     jobj
                         [ "textDocument", jobj [ "uri", jstr uri; "version", jint state.Version ]
-                          "contentChanges", JArray(jobj [ "text", jstr text ]) :> JToken ]
+                          "contentChanges", JsonArray(jobj [ "text", jstr text ] :> JsonNode) :> JsonNode ]
 
                 do! jsonRpc.NotifyWithParameterObjectAsync("textDocument/didChange", didChangeParams)
                 return uri
@@ -383,8 +385,8 @@ type internal FsAutoCompleteBridge() =
 
     // WithDocument: gate wraps only SyncDocument; released before LSP invoke
     member private this.WithDocument
-        (path: string, providedText: string option, methodName: string, mkParams: string -> JObject)
-        : Task<JToken> =
+        (path: string, providedText: string option, methodName: string, mkParams: string -> JsonObject)
+        : Task<JsonNode> =
         task {
             let! jsonRpc = this.EnsureStarted()
 
@@ -404,11 +406,11 @@ type internal FsAutoCompleteBridge() =
 
             // Gate released — StreamJsonRpc handles concurrent requests natively
             let parameters = mkParams uri
-            let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>(methodName, parameters)
-            return JObject(JProperty("status", "ok"), JProperty("result", response)) :> JToken
+            let! response = jsonRpc.InvokeWithParameterObjectAsync<JsonNode>(methodName, parameters)
+            return jobj [ "status", jstr "ok"; "result", response ] :> JsonNode
         }
 
-    member private this.PositionParams(uri: string, line: int, character: int) =
+    member private this.PositionParams(uri: string, line: int, character: int) : JsonObject =
         jobj
             [ "textDocument", jobj [ "uri", jstr uri ]
               "position", jobj [ "line", jint line; "character", jint character ] ]
@@ -423,7 +425,7 @@ type internal FsAutoCompleteBridge() =
 
                 match args.triggerCharacter with
                 | Some ch ->
-                    parameters["context"] <- jobj [ "triggerKind", jint 2; "triggerCharacter", jstr ch ]
+                    parameters["context"] <- jobj [ "triggerKind", jint 2; "triggerCharacter", jstr ch ] :> JsonNode
                     parameters
                 | None -> parameters
         )
@@ -448,11 +450,12 @@ type internal FsAutoCompleteBridge() =
                     jobj
                         [ "includeDeclaration",
                           jbool (args.includeDeclaration |> Option.defaultValue false) ]
+                    :> JsonNode
 
                 baseParams
         )
 
-    member this.WorkspaceSymbol(args: WorkspaceSymbolArgs) : Task<JToken> =
+    member this.WorkspaceSymbol(args: WorkspaceSymbolArgs) : Task<JsonNode> =
         task {
             let! jsonRpc = this.EnsureStarted()
 
@@ -462,31 +465,31 @@ type internal FsAutoCompleteBridge() =
 
             // No document sync needed — just invoke directly, no gate
             let parameters = jobj [ "query", jstr args.query ]
-            let! response = jsonRpc.InvokeWithParameterObjectAsync<JToken>("workspace/symbol", parameters)
-            return JObject(JProperty("status", "ok"), JProperty("result", response)) :> JToken
+            let! response = jsonRpc.InvokeWithParameterObjectAsync<JsonNode>("workspace/symbol", parameters)
+            return jobj [ "status", jstr "ok"; "result", response ] :> JsonNode
         }
 
-    member _.Diagnostics(args: DiagnosticsArgs) : Task<JToken> =
+    member _.Diagnostics(args: DiagnosticsArgs) : Task<JsonNode> =
         task {
             let resolveByUri (uri: string) =
                 match diagnostics.TryGetValue(uri) with
                 | true, payload -> payload.DeepClone()
-                | false, _ -> JArray() :> JToken
+                | false, _ -> JsonArray() :> JsonNode
 
             match args.path with
             | Some path ->
                 let uri = toFileUri path
-                return JObject(JProperty("status", "ok"), JProperty("result", resolveByUri uri)) :> JToken
+                return jobj [ "status", jstr "ok"; "result", resolveByUri uri ] :> JsonNode
             | None ->
-                let root = JObject()
+                let root = JsonObject()
 
                 for KeyValue(uri, payload) in diagnostics do
                     root[uri] <- payload.DeepClone()
 
-                return JObject(JProperty("status", "ok"), JProperty("result", root)) :> JToken
+                return jobj [ "status", jstr "ok"; "result", root :> JsonNode ] :> JsonNode
         }
 
-    member this.Formatting(args: FormattingArgs) : Task<JToken> =
+    member this.Formatting(args: FormattingArgs) : Task<JsonNode> =
         task {
             let! jsonRpc = this.EnsureStarted()
 
@@ -508,26 +511,23 @@ type internal FsAutoCompleteBridge() =
                 }
 
             let formatParams =
-                JObject(
-                    JProperty("textDocument", JObject(JProperty("uri", uri))),
-                    JProperty("options", JObject(
-                        JProperty("tabSize", 4),
-                        JProperty("insertSpaces", true)))
-                )
+                jobj
+                    [ "textDocument", jobj [ "uri", jstr uri ]
+                      "options", jobj [ "tabSize", jint 4; "insertSpaces", jbool true ] ]
 
-            let! editsToken = jsonRpc.InvokeWithParameterObjectAsync<JToken>("textDocument/formatting", formatParams)
+            let! editsToken = jsonRpc.InvokeWithParameterObjectAsync<JsonNode>("textDocument/formatting", formatParams)
 
             // Apply text edits to produce formatted result
-            let applyEdits (text: string) (edits: JArray) =
+            let applyEdits (text: string) (edits: JsonArray) =
                 // Sort edits in reverse order (bottom to top) to preserve positions
-                let getRangeStart (e: JToken) =
+                let getRangeStart (e: JsonNode) =
                     let r = e["range"]
                     let s = r["start"]
-                    s["line"].Value<int>(), s["character"].Value<int>()
+                    s["line"].GetValue<int>(), s["character"].GetValue<int>()
 
                 let sortedEdits =
                     edits
-                    |> Seq.cast<JToken>
+                    |> Seq.cast<JsonNode>
                     |> Seq.sortByDescending (fun e ->
                         let sl, sc = getRangeStart e
                         sl, sc)
@@ -535,15 +535,15 @@ type internal FsAutoCompleteBridge() =
 
                 let lines = text.Split('\n') |> Array.map (fun l -> l.TrimEnd('\r'))
 
-                let applyEdit (linesArr: string array) (edit: JToken) =
+                let applyEdit (linesArr: string array) (edit: JsonNode) =
                     let range = edit["range"]
                     let startPos = range["start"]
                     let endPos = range["end"]
-                    let startLine = startPos["line"].Value<int>()
-                    let startChar = startPos["character"].Value<int>()
-                    let endLine = endPos["line"].Value<int>()
-                    let endChar = endPos["character"].Value<int>()
-                    let newText = edit["newText"].Value<string>()
+                    let startLine = startPos["line"].GetValue<int>()
+                    let startChar = startPos["character"].GetValue<int>()
+                    let endLine = endPos["line"].GetValue<int>()
+                    let endChar = endPos["character"].GetValue<int>()
+                    let newText = edit["newText"].GetValue<string>()
 
                     let before =
                         if startLine < linesArr.Length && startChar > 0 then
@@ -574,46 +574,46 @@ type internal FsAutoCompleteBridge() =
 
             let formatted =
                 match editsToken with
-                | :? JArray as edits when edits.Count > 0 ->
+                | :? JsonArray as edits when edits.Count > 0 ->
                     applyEdits originalText edits
                 | _ -> originalText
 
             return
-                JObject(
-                    JProperty("status", "ok"),
-                    JProperty("result", JObject(
-                        JProperty("formatted", formatted),
-                        JProperty("edits", if editsToken :? JArray then editsToken else JArray() :> JToken)
-                    ))
-                )
-                :> JToken
+                jobj
+                    [ "status", jstr "ok"
+                      "result",
+                      jobj
+                          [ "formatted", jstr formatted
+                            "edits",
+                            (match editsToken with
+                             | :? JsonArray -> editsToken
+                             | _ -> JsonArray() :> JsonNode) ] :> JsonNode ]
+                :> JsonNode
         }
 
-    member this.CodeAction(args: CodeActionArgs) : Task<JToken> =
+    member this.CodeAction(args: CodeActionArgs) : Task<JsonNode> =
         this.WithDocument(
             args.path,
             args.text,
             "textDocument/codeAction",
             fun uri ->
-                let pos = JObject(JProperty("line", args.line), JProperty("character", args.character))
-                JObject(
-                    JProperty("textDocument", JObject(JProperty("uri", uri))),
-                    JProperty("range", JObject(JProperty("start", pos), JProperty("end", pos))),
-                    JProperty("context", JObject(JProperty("diagnostics", JArray())))
-                )
+                let pos = jobj [ "line", jint args.line; "character", jint args.character ]
+                jobj
+                    [ "textDocument", jobj [ "uri", jstr uri ]
+                      "range", jobj [ "start", pos :> JsonNode; "end", pos :> JsonNode ]
+                      "context", jobj [ "diagnostics", JsonArray() :> JsonNode ] ]
         )
 
-    member this.Rename(args: RenameArgs) : Task<JToken> =
+    member this.Rename(args: RenameArgs) : Task<JsonNode> =
         this.WithDocument(
             args.path,
             args.text,
             "textDocument/rename",
             fun uri ->
-                JObject(
-                    JProperty("textDocument", JObject(JProperty("uri", uri))),
-                    JProperty("position", JObject(JProperty("line", args.line), JProperty("character", args.character))),
-                    JProperty("newName", args.newName)
-                )
+                jobj
+                    [ "textDocument", jobj [ "uri", jstr uri ]
+                      "position", jobj [ "line", jint args.line; "character", jint args.character ]
+                      "newName", jstr args.newName ]
         )
 
     interface IDisposable with

--- a/Program.fs
+++ b/Program.fs
@@ -11,7 +11,8 @@ open FsLangMcp.Tools
 open FsMcp.Core
 open FsMcp.Core.Validation
 open FsMcp.Server
-open Newtonsoft.Json.Linq
+open System.Text.Json
+open System.Text.Json.Nodes
 
 // ─── CLI helpers ───────────────────────────────────────────────────────────────
 
@@ -36,36 +37,34 @@ let private runProcess (fileName: string) (args: string list) =
     proc.WaitForExit()
     proc.ExitCode, stdout, stderr
 
-let private parseProjInfoOutput (path: string) (exitCode: int) (stdout: string) (stderr: string) : JToken =
+let private parseProjInfoOutput (path: string) (exitCode: int) (stdout: string) (stderr: string) : JsonNode =
     if exitCode <> 0 then
-        JObject(
-            JProperty("error", $"proj-info failed (exit {exitCode})"),
-            JProperty("stderr", stderr)
-        ) :> JToken
+        jobj [ "error", jstr $"proj-info failed (exit {exitCode})"; "stderr", jstr stderr ]
+        :> JsonNode
     elif String.IsNullOrWhiteSpace(stdout) then
-        JObject(JProperty("error", "proj-info produced no output")) :> JToken
+        jobj [ "error", jstr "proj-info produced no output" ] :> JsonNode
     else
-        let token = JToken.Parse(stdout)
+        let token = JsonNode.Parse(stdout)
         let json =
             match token with
-            | :? JArray as arr when arr.Count > 0 ->
+            | :? JsonArray as arr when arr.Count > 0 ->
                 match arr.[0] with
-                | :? JObject as obj -> obj
-                | other -> JObject(JProperty("warning", sprintf "unexpected element type: %s" (other.Type.ToString())))
-            | :? JObject as obj -> obj
-            | _ -> JObject()
+                | :? JsonObject as obj -> obj
+                | other -> jobj [ "warning", jstr (sprintf "unexpected element type: %s" (other.GetValueKind().ToString())) ]
+            | :? JsonObject as obj -> obj
+            | _ -> JsonObject()
         let otherOptions =
             json["OtherOptions"]
             |> Option.ofObj
-            |> Option.map (fun t -> t.ToObject<string[]>())
+            |> Option.map (fun t -> t.Deserialize<string[]>() |> Option.ofObj |> Option.defaultValue [||])
             |> Option.defaultValue [||]
-        JObject(
-            JProperty("projectPath", path),
-            JProperty("otherOptions", JArray(otherOptions)),
-            JProperty("optionsCount", otherOptions.Length)
-        ) :> JToken
+        jobj
+            [ "projectPath", jstr path
+              "otherOptions", JsonArray(otherOptions |> Array.map jstr) :> JsonNode
+              "optionsCount", jint otherOptions.Length ]
+        :> JsonNode
 
-let private runProjInfoAsync (path: string) : Task<JToken> = task {
+let private runProjInfoAsync (path: string) : Task<JsonNode> = task {
     let psi = ProcessStartInfo()
     psi.FileName <- "proj-info"
     psi.UseShellExecute <- false
@@ -307,7 +306,7 @@ let main argv =
                         (fun args ->
                             let path = args.projectPath
                             if String.IsNullOrWhiteSpace(path) then
-                                toolResult (Task.FromException<JToken>(ArgumentException "projectPath is required"))
+                                toolResult (Task.FromException<JsonNode>(ArgumentException "projectPath is required"))
                             else
                                 toolResult (runProjInfoAsync path))
                     |> unwrapResult

--- a/Tools.fs
+++ b/Tools.fs
@@ -5,23 +5,32 @@ open System.Threading.Tasks
 open FsLangMcp.Types
 open FsMcp.Core
 open FsMcp.Server
-open Newtonsoft.Json
-open Newtonsoft.Json.Linq
+open System.Text.Encodings.Web
+open System.Text.Json
+open System.Text.Json.Nodes
 
 // ─── MCP helpers ───────────────────────────────────────────────────────────────
 
+let private serializeOpts =
+    JsonSerializerOptions(Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
+
+let private renderOpts =
+    JsonSerializerOptions(
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = true)
+
 let toolErrorToJson (err: ToolError) : string =
     match err with
-    | InvalidArgs msg  -> sprintf """{"errorKind":"InvalidArgs","message":%s}"""   (JsonConvert.SerializeObject msg)
-    | NotReady msg     -> sprintf """{"errorKind":"NotReady","message":%s}"""      (JsonConvert.SerializeObject msg)
-    | InfraFailure ex  -> sprintf """{"errorKind":"InfraFailure","message":%s}"""  (JsonConvert.SerializeObject ex.Message)
-    | FcsAborted msg   -> sprintf """{"errorKind":"FcsAborted","message":%s}"""    (JsonConvert.SerializeObject msg)
-    | FileNotFound msg -> sprintf """{"errorKind":"FileNotFound","message":%s}"""  (JsonConvert.SerializeObject msg)
+    | InvalidArgs msg  -> sprintf """{"errorKind":"InvalidArgs","message":%s}"""   (JsonSerializer.Serialize(msg, serializeOpts))
+    | NotReady msg     -> sprintf """{"errorKind":"NotReady","message":%s}"""      (JsonSerializer.Serialize(msg, serializeOpts))
+    | InfraFailure ex  -> sprintf """{"errorKind":"InfraFailure","message":%s}"""  (JsonSerializer.Serialize(ex.Message, serializeOpts))
+    | FcsAborted msg   -> sprintf """{"errorKind":"FcsAborted","message":%s}"""    (JsonSerializer.Serialize(msg, serializeOpts))
+    | FileNotFound msg -> sprintf """{"errorKind":"FileNotFound","message":%s}"""  (JsonSerializer.Serialize(msg, serializeOpts))
 
-let renderToken (token: JToken) =
-    token.ToString(Formatting.Indented)
+let renderToken (token: JsonNode) =
+    JsonSerializer.Serialize(token, renderOpts)
 
-let toolResult (work: Task<JToken>) : Task<Result<Content list, McpError>> =
+let toolResult (work: Task<JsonNode>) : Task<Result<Content list, McpError>> =
     task {
         try
             let! payload = work

--- a/Types.fs
+++ b/Types.fs
@@ -2,7 +2,8 @@ module FsLangMcp.Types
 
 open System
 open System.IO
-open Newtonsoft.Json.Linq
+open System.Text.Json
+open System.Text.Json.Nodes
 
 // ─── Tool error DU ─────────────────────────────────────────────────────────────
 
@@ -114,15 +115,15 @@ type internal CliParseResult =
 
 // ─── Helper utility functions ──────────────────────────────────────────────────
 
-let jobj (props: (string * JToken) list) =
-    let result = JObject()
+let jobj (props: (string * JsonNode) list) =
+    let result = JsonObject()
     for (key, value) in props do
         result[key] <- value
     result
 
-let jstr (value: string) = JValue(value) :> JToken
-let jint (value: int) = JValue(value) :> JToken
-let jbool (value: bool) = JValue(value) :> JToken
+let jstr (value: string) : JsonNode = JsonValue.Create(value)
+let jint (value: int) : JsonNode = JsonValue.Create(value)
+let jbool (value: bool) : JsonNode = JsonValue.Create(value)
 
 let toFileUri (path: string) =
     let fullPath = Path.GetFullPath(path)

--- a/tests/FsLangMcp.Tests/FcsBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/FcsBridgeTests.fs
@@ -6,6 +6,9 @@ open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Text
+open System.Text.Encodings.Web
+open System.Text.Json
+open System.Text.Json.Nodes
 open Xunit
 open FsLangMcp.Types
 open FsLangMcp.Tools
@@ -49,8 +52,22 @@ let ``ToolError FileNotFound serializes with correct errorKind`` () =
 let ``ToolError message with quotes is properly escaped`` () =
     let json = toolErrorToJson (InvalidArgs "message with \"quotes\"")
     Assert.Contains("\"errorKind\":\"InvalidArgs\"", json)
-    // Newtonsoft.Json should escape the inner quotes
+    // System.Text.Json with UnsafeRelaxedJsonEscaping escapes inner quotes as \" (not \u0022)
     Assert.Contains("\\\"quotes\\\"", json)
+
+[<Fact>]
+let ``renderToken preserves F# type signature characters without unicode escaping`` () =
+    // Regression for STJ default encoder mangling 'a -> 'b to \u0027a -\u003E \u0027b
+    let renderOpts =
+        JsonSerializerOptions(
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            WriteIndented = true)
+    let node = JsonObject()
+    node["typeString"] <- JsonValue.Create("'a -> 'b when 'a : comparison")
+    let rendered = JsonSerializer.Serialize(node, renderOpts)
+    Assert.Contains("'a -> 'b", rendered)
+    Assert.DoesNotContain("\\u0027", rendered)
+    Assert.DoesNotContain("\\u003E", rendered)
 
 // Helpers
 

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -18,7 +18,6 @@
     <PackageReference Include="FSharp.Compiler.Service" Version="43.12.201" />
     <PackageReference Include="FsMcp.Server" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Closes #13

## What changed

Full replacement of Newtonsoft.Json with System.Text.Json.Nodes across all source files. Zero behavior change to API contracts.

### Files changed
- **Types.fs** — `jobj`/`jstr`/`jint`/`jbool` helpers now return `JsonNode`/`JsonObject`/`JsonValue`
- **Tools.fs** — `toolErrorToJson` and `renderToken` use `JsonSerializer` with `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` (preserves `'a -> 'b` literals, avoids `\u0027`/`\u003E` mangling)
- **LspBridge.fs** — `JsonMessageFormatter` → `SystemTextJsonFormatter`; all `InvokeWithParameterObjectAsync<JToken>` → `<JsonNode>`
- **FcsBridge.fs** — all `Task<JToken>` → `Task<JsonNode>`; JSON construction via `jobj` helpers
- **Program.fs** — `parseProjInfoOutput` uses `JsonNode.Parse` and `GetValueKind().ToString()`
- **FsLangMcp.fsproj** — `Newtonsoft.Json` `PackageReference` removed
- **Tests** — `Newtonsoft.Json` removed from test project; 1 new regression test for `renderToken` encoding

### Key correctness notes
- `UnsafeRelaxedJsonEscaping` is applied to **both** `toolErrorToJson` and `renderToken` — ensures F# type signatures containing `'`, `<`, `>`, `&` render correctly to MCP clients
- Null JsonNode values (`null`) in `JsonObject` serialize as `"key": null`, equivalent to Newtonsoft's `JValue.CreateNull()`
- LSP params are hand-built `JsonObject` with explicit camelCase keys — `SystemTextJsonFormatter` naming policy is a non-issue

### Build & tests
- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — 18/18 pass (1 new regression test added)