### PR TITLE
feat(ux): clearer agent-facing contracts (closes #77, #81)

### DIFF
--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -290,6 +290,32 @@ type internal FcsBridge() =
               "text", jstr text ]
         :> JsonNode
 
+    // Validate that a 'path' argument points to an existing source file, not a directory.
+    // Returns Some errorNode when validation fails; None when the path is acceptable.
+    let validateSourcePath (toolName: string) (path: string) : JsonNode option =
+        let fullPath = normalizePath path
+
+        if Directory.Exists(fullPath) then
+            Some(
+                jobj
+                    [ "status", jstr "error"
+                      "errorKind", jstr "InvalidArgument"
+                      "message",
+                      jstr
+                          $"%s{toolName} expects 'path' to be a source file (.fs/.fsi), not a directory. To search project-wide, pass any source file in the project as 'path' and the .fsproj as 'projectPath'." ]
+                :> JsonNode
+            )
+        elif not (File.Exists(fullPath)) then
+            Some(
+                jobj
+                    [ "status", jstr "error"
+                      "errorKind", jstr "InvalidArgument"
+                      "message", jstr $"%s{toolName}: path does not exist or is not readable: %s{fullPath}" ]
+                :> JsonNode
+            )
+        else
+            None
+
     // Build a stable cache key from projectPath and projectOptions list
     let makeCacheKey (projectPath: string option) (projectOptions: string list option) =
         let pp = projectPath |> Option.defaultValue ""
@@ -441,6 +467,10 @@ type internal FcsBridge() =
 
     member this.ParseAndCheckFile(args: FcsParseAndCheckArgs) : Task<JsonNode> =
         task {
+            match validateSourcePath "fcs_parse_and_check_file" args.path with
+            | Some err -> return err
+            | None ->
+
             let! path, _, optionsSource, projectOptions, parseResults, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
 
@@ -542,6 +572,10 @@ type internal FcsBridge() =
 
     member this.FileSymbols(args: FcsFileSymbolsArgs) : Task<JsonNode> =
         task {
+            match validateSourcePath "fcs_file_symbols" args.path with
+            | Some err -> return err
+            | None ->
+
             let! path, _, optionsSource, _, parseResults, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
 
@@ -591,6 +625,10 @@ type internal FcsBridge() =
 
     member this.FileOutline(args: FcsFileOutlineArgs) : Task<JsonNode> =
         task {
+            match validateSourcePath "fcs_file_outline" args.path with
+            | Some err -> return err
+            | None ->
+
             let! path, _, optionsSource, _, parseResults, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
 
@@ -657,6 +695,10 @@ type internal FcsBridge() =
 
             if String.IsNullOrWhiteSpace(query) then
                 invalidArg (nameof args.symbolQuery) "symbolQuery must be non-empty."
+
+            match validateSourcePath "fcs_project_symbol_uses" args.path with
+            | Some err -> return err
+            | None ->
 
             let! _, _, optionsSource, projectOptions, _, _ =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
@@ -725,6 +767,10 @@ type internal FcsBridge() =
 
             if String.IsNullOrWhiteSpace(query) then
                 invalidArg (nameof args.symbolQuery) "symbolQuery must be non-empty."
+
+            match validateSourcePath "fcs_find_symbol" args.path with
+            | Some err -> return err
+            | None ->
 
             let! _, _, optionsSource, projectOptions, _, _ =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
@@ -817,6 +863,10 @@ type internal FcsBridge() =
 
     member this.TypeAtPosition(args: FcsTypeAtPositionArgs) : Task<JsonNode> =
         task {
+            match validateSourcePath "fcs_type_at_position" args.path with
+            | Some err -> return err
+            | None ->
+
             let! path, source, optionsSource, _, _, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
 
@@ -909,6 +959,10 @@ type internal FcsBridge() =
 
     member this.SymbolAtWord(args: FcsSymbolAtWordArgs) : Task<JsonNode> =
         task {
+            match validateSourcePath "fcs_symbol_at_word" args.path with
+            | Some err -> return err
+            | None ->
+
             let! path, source, optionsSource, _, _, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
 
@@ -1230,6 +1284,10 @@ type internal FcsBridge() =
 
     member this.SignatureHelp(args: FcsSignatureHelpArgs) : Task<JsonNode> =
         task {
+            match validateSourcePath "fcs_signature_help" args.path with
+            | Some err -> return err
+            | None ->
+
             let! path, source, optionsSource, _, _, checkedResults =
                 this.PrepareCheckContext(args.path, args.text, args.projectPath, args.projectOptions)
 

--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -291,9 +291,12 @@ type internal FcsBridge() =
         :> JsonNode
 
     // Validate that a 'path' argument points to an existing source file, not a directory.
+    // When the caller supplies a non-empty 'text' buffer the file does not need to
+    // exist on disk — we still reject directories (the actual papercut from #77).
     // Returns Some errorNode when validation fails; None when the path is acceptable.
-    let validateSourcePath (toolName: string) (path: string) : JsonNode option =
+    let validateSourcePath (toolName: string) (text: string option) (path: string) : JsonNode option =
         let fullPath = normalizePath path
+        let hasText = text |> Option.exists (fun t -> t <> "")
 
         if Directory.Exists(fullPath) then
             Some(
@@ -305,7 +308,7 @@ type internal FcsBridge() =
                           $"%s{toolName} expects 'path' to be a source file (.fs/.fsi), not a directory. To search project-wide, pass any source file in the project as 'path' and the .fsproj as 'projectPath'." ]
                 :> JsonNode
             )
-        elif not (File.Exists(fullPath)) then
+        elif not hasText && not (File.Exists(fullPath)) then
             Some(
                 jobj
                     [ "status", jstr "error"
@@ -467,7 +470,7 @@ type internal FcsBridge() =
 
     member this.ParseAndCheckFile(args: FcsParseAndCheckArgs) : Task<JsonNode> =
         task {
-            match validateSourcePath "fcs_parse_and_check_file" args.path with
+            match validateSourcePath "fcs_parse_and_check_file" args.text args.path with
             | Some err -> return err
             | None ->
 
@@ -572,7 +575,7 @@ type internal FcsBridge() =
 
     member this.FileSymbols(args: FcsFileSymbolsArgs) : Task<JsonNode> =
         task {
-            match validateSourcePath "fcs_file_symbols" args.path with
+            match validateSourcePath "fcs_file_symbols" args.text args.path with
             | Some err -> return err
             | None ->
 
@@ -625,7 +628,7 @@ type internal FcsBridge() =
 
     member this.FileOutline(args: FcsFileOutlineArgs) : Task<JsonNode> =
         task {
-            match validateSourcePath "fcs_file_outline" args.path with
+            match validateSourcePath "fcs_file_outline" args.text args.path with
             | Some err -> return err
             | None ->
 
@@ -696,7 +699,7 @@ type internal FcsBridge() =
             if String.IsNullOrWhiteSpace(query) then
                 invalidArg (nameof args.symbolQuery) "symbolQuery must be non-empty."
 
-            match validateSourcePath "fcs_project_symbol_uses" args.path with
+            match validateSourcePath "fcs_project_symbol_uses" args.text args.path with
             | Some err -> return err
             | None ->
 
@@ -768,7 +771,7 @@ type internal FcsBridge() =
             if String.IsNullOrWhiteSpace(query) then
                 invalidArg (nameof args.symbolQuery) "symbolQuery must be non-empty."
 
-            match validateSourcePath "fcs_find_symbol" args.path with
+            match validateSourcePath "fcs_find_symbol" args.text args.path with
             | Some err -> return err
             | None ->
 
@@ -863,7 +866,7 @@ type internal FcsBridge() =
 
     member this.TypeAtPosition(args: FcsTypeAtPositionArgs) : Task<JsonNode> =
         task {
-            match validateSourcePath "fcs_type_at_position" args.path with
+            match validateSourcePath "fcs_type_at_position" args.text args.path with
             | Some err -> return err
             | None ->
 
@@ -959,7 +962,7 @@ type internal FcsBridge() =
 
     member this.SymbolAtWord(args: FcsSymbolAtWordArgs) : Task<JsonNode> =
         task {
-            match validateSourcePath "fcs_symbol_at_word" args.path with
+            match validateSourcePath "fcs_symbol_at_word" args.text args.path with
             | Some err -> return err
             | None ->
 
@@ -1284,7 +1287,7 @@ type internal FcsBridge() =
 
     member this.SignatureHelp(args: FcsSignatureHelpArgs) : Task<JsonNode> =
         task {
-            match validateSourcePath "fcs_signature_help" args.path with
+            match validateSourcePath "fcs_signature_help" args.text args.path with
             | Some err -> return err
             | None ->
 

--- a/Program.fs
+++ b/Program.fs
@@ -215,7 +215,7 @@ let main argv =
                 tool (
                     TypedTool.define<CompletionArgs>
                         "textDocument_completion"
-                        "Raw LSP proxy to fsautocomplete textDocument/completion. Exact-position IDE primitive; requires set_project first. Prefer agent-friendly FCS/navigation tools for codebase understanding. line/character are 0-based. Pass 'text' for unsaved content."
+                        "[FSAC] Raw LSP proxy to fsautocomplete textDocument/completion. Exact-position IDE primitive; requires set_project first. Prefer agent-friendly FCS/navigation tools for codebase understanding. line/character are 0-based. Pass 'text' for unsaved content."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.Completion args)))
                     |> unwrapResult
                 )
@@ -223,7 +223,7 @@ let main argv =
                 tool (
                     TypedTool.define<PositionArgs>
                         "textDocument_definition"
-                        "Raw LSP proxy to fsautocomplete textDocument/definition. Exact-position IDE primitive; requires set_project first. line/character are 0-based. Pass 'text' for unsaved content."
+                        "[FSAC] Raw LSP proxy to fsautocomplete textDocument/definition. Exact-position IDE primitive; requires set_project first. line/character are 0-based. Pass 'text' for unsaved content."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.Definition args)))
                     |> unwrapResult
                 )
@@ -231,7 +231,7 @@ let main argv =
                 tool (
                     TypedTool.define<ReferencesArgs>
                         "textDocument_references"
-                        "Raw LSP proxy to fsautocomplete textDocument/references. Exact-position IDE primitive; requires set_project first. For query-based agent workflows prefer project symbol-use tools. line/character are 0-based. Pass 'text' for unsaved content."
+                        "[FSAC] Raw LSP proxy to fsautocomplete textDocument/references. Exact-position IDE primitive; requires set_project first. For query-based agent workflows prefer project symbol-use tools. line/character are 0-based. Pass 'text' for unsaved content."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.References args)))
                     |> unwrapResult
                 )
@@ -239,7 +239,7 @@ let main argv =
                 tool (
                     TypedTool.define<WorkspaceSymbolArgs>
                         "workspace_symbol"
-                        "Raw LSP proxy to fsautocomplete workspace/symbol. Useful for quick lookup after set_project, but returns IDE-shaped results without source context."
+                        "[FSAC] Raw LSP proxy to fsautocomplete workspace/symbol. Useful for quick lookup after set_project, but returns IDE-shaped results without source context."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.WorkspaceSymbol args)))
                     |> unwrapResult
                 )
@@ -247,7 +247,7 @@ let main argv =
                 tool (
                     TypedTool.define<DiagnosticsArgs>
                         "workspace_diagnostics"
-                        "Raw cached LSP publishDiagnostics payload, either for one file or all files. Requires set_project first. Use for current FSAC/compiler/analyzer diagnostics; it does not run build/tests."
+                        "[FSAC] Raw cached LSP publishDiagnostics payload, either for one file or all files. Requires set_project first. Use for current FSAC/compiler/analyzer diagnostics; it does not run build/tests."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.Diagnostics args)))
                     |> unwrapResult
                 )
@@ -255,7 +255,7 @@ let main argv =
                 tool (
                     TypedTool.define<FSharpCompileArgs>
                         "fsharp_compile"
-                        "Agent-friendly FCS project validation. Requires an explicit .fsproj path, loads project options through Ionide.ProjInfo, then runs FSharpChecker.ParseAndCheckProject. Does not require set_project, does not run dotnet build/test, and does not emit assemblies."
+                        "[FCS in-process] Agent-friendly FCS project validation. Requires an explicit .fsproj path, loads project options through Ionide.ProjInfo, then runs FSharpChecker.ParseAndCheckProject. Does not require set_project, does not run dotnet build/test, and does not emit assemblies."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.CompileProject args)))
                     |> unwrapResult
                 )
@@ -263,7 +263,7 @@ let main argv =
                 tool (
                     TypedTool.define<SetProjectArgs>
                         "set_project"
-                        "Initialize or switch the FSAC/LSP project context. Must be called before textDocument_* and workspace_* tools. Accepts .fsproj, .sln, .slnx, or directory. Waits up to 30s for workspace load and clears FCS caches."
+                        "[FSAC] Initialize or switch the FSAC/LSP project context. Must be called before textDocument_* and workspace_* tools. Accepts .fsproj, .sln, .slnx, or directory. Waits up to 30s for workspace load and clears FCS caches."
                         (fun args ->
                             toolResult (
                                 runLimited lspGate (fun () ->
@@ -279,7 +279,7 @@ let main argv =
                 tool (
                     TypedTool.define<ProjectHealthArgs>
                         "project_health"
-                        "Fast read-only preflight for one F# project. Reports whether FsLangMCP can trust semantic tooling, project options availability, source file readability, analyzer setup, test project discovery, and current LSP readiness. Does not start/switch FSAC, run compile, or run tests."
+                        "[FCS in-process] Fast read-only preflight for one F# project. Reports whether FsLangMCP can trust semantic tooling, project options availability, source file readability, analyzer setup, test project discovery, and current LSP readiness. Does not start/switch FSAC, run compile, or run tests."
                         (fun args ->
                             let snapshot =
                                 { ProjectPath = bridge.CurrentProjectPath
@@ -299,7 +299,7 @@ let main argv =
                 tool (
                     TypedTool.define<FSharpProjectInspectArgs>
                         "fsharp_project_inspect"
-                        "Read-only .fsproj inspection for agents. Returns project identity, compile order, package/project references, signature/implementation pairing, and shared scan filtering summary. Does not build, restore, test, edit files, or require set_project."
+                        "[FCS in-process] Read-only .fsproj inspection for agents. Returns project identity, compile order, package/project references, signature/implementation pairing, and shared scan filtering summary. Does not build, restore, test, edit files, or require set_project."
                         (fun args -> toolResult (Task.FromResult(inspectProject args)))
                     |> unwrapResult
                 )
@@ -307,7 +307,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsParseAndCheckArgs>
                         "fcs_parse_and_check_file"
-                        "Agent-friendly FCS parse+typecheck for one file. Prefer passing projectPath (.fsproj) for accurate project context; projectOptions can override. Falls back to script inference only when no project can be resolved. Pass 'text' for unsaved content."
+                        "[FCS in-process] Agent-friendly FCS parse+typecheck for one file. Prefer passing projectPath (.fsproj) for accurate project context; projectOptions can override. Falls back to script inference only when no project can be resolved. Pass 'text' for unsaved content."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.ParseAndCheckFile args)))
                     |> unwrapResult
                 )
@@ -315,7 +315,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsFileSymbolsArgs>
                         "fcs_file_symbols"
-                        "Raw FCS symbol extraction for one file. Can be noisy on large files; default returns definitions, includeAllUses returns locals/parameters/usages too. Prefer fcs_file_outline for normal agent navigation. Pass projectPath when possible and 'text' for unsaved content."
+                        "[FCS in-process] Raw FCS symbol extraction for one file. Can be noisy on large files; default returns definitions, includeAllUses returns locals/parameters/usages too. Prefer fcs_file_outline for normal agent navigation. Pass projectPath when possible and 'text' for unsaved content."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.FileSymbols args)))
                     |> unwrapResult
                 )
@@ -323,7 +323,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsFileOutlineArgs>
                         "fcs_file_outline"
-                        "Agent-friendly compact F# outline for one file. Filters local/noisy symbols by default and returns name, kind, range, signature/type, accessibility, and declaration range. Prefer this over fcs_file_symbols for navigation."
+                        "[FCS in-process] Agent-friendly compact F# outline for one file. Filters local/noisy symbols by default and returns name, kind, range, signature/type, accessibility, and declaration range. Prefer this over fcs_file_symbols for navigation."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.FileOutline args)))
                     |> unwrapResult
                 )
@@ -331,7 +331,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsProjectSymbolUsesArgs>
                         "fcs_project_symbol_uses"
-                        "Agent-friendly FCS project-wide symbol-use search by symbol name/full name. Results are cached by resolved project options. Prefer exact=true for narrow queries. Pass projectPath when possible and 'text' for unsaved content."
+                        "[FCS in-process] Agent-friendly FCS project-wide symbol-use search by symbol name/full name. Results are cached by resolved project options. Prefer exact=true for narrow queries. Pass projectPath when possible and 'text' for unsaved content."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.ProjectSymbolUses args)))
                     |> unwrapResult
                 )
@@ -339,7 +339,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsFindSymbolArgs>
                         "fcs_find_symbol"
-                        "Agent-friendly project-wide symbol search with grouped definitions/references and source line context. Better than chaining workspace_symbol, fcs_project_symbol_uses, and shell line reads. Pass projectPath when possible."
+                        "[FCS in-process] Agent-friendly project-wide symbol search with grouped definitions/references and source line context. Better than chaining workspace_symbol, fcs_project_symbol_uses, and shell line reads. Pass projectPath when possible."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.FindSymbol args)))
                     |> unwrapResult
                 )
@@ -347,7 +347,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsSymbolAtWordArgs>
                         "fcs_symbol_at_word"
-                        "Tolerant FCS symbol lookup for agent workflows. Accepts a line plus word/occurrence, finds the candidate span, and returns symbol identity, kind, type string, definition range, and optional documentation. Prefer over exact-position hover/type queries."
+                        "[FCS in-process] Tolerant FCS symbol lookup for agent workflows. Accepts a line plus word/occurrence, finds the candidate span, and returns symbol identity, kind, type string, definition range, and optional documentation. Prefer over exact-position hover/type queries."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.SymbolAtWord args)))
                     |> unwrapResult
                 )
@@ -355,7 +355,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsProjectOutlineArgs>
                         "fcs_project_outline"
-                        "Agent-friendly project outline over filtered compile files. Uses shared filtering to skip generated/build artifacts and returns compact per-file outlines. Use maxFiles/maxResultsPerFile on large projects."
+                        "[FCS in-process] Agent-friendly project outline over filtered compile files. Uses shared filtering to skip generated/build artifacts and returns compact per-file outlines. Use maxFiles/maxResultsPerFile on large projects."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.ProjectOutline args)))
                     |> unwrapResult
                 )
@@ -363,7 +363,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsTypeAtPositionArgs>
                         "fcs_type_at_position"
-                        "Low-level exact-position FCS type/symbol query. Works without LSP set_project, but requires accurate line/character and project context for good results. Prefer fcs_symbol_at_word for normal agent workflows. Pass projectPath/projectOptions and 'text' when available."
+                        "[FCS in-process] Low-level exact-position FCS type/symbol query. Works without LSP set_project, but requires accurate line/character and project context for good results. Prefer fcs_symbol_at_word for normal agent workflows. Pass projectPath/projectOptions and 'text' when available."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.TypeAtPosition args)))
                     |> unwrapResult
                 )
@@ -371,7 +371,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsSignatureHelpArgs>
                         "fcs_signature_help"
-                        "Low-level exact-position FCS signature help. Returns overloads/parameters around a call site. line/character are 0-based. Pass projectPath/projectOptions and 'text' when available."
+                        "[FCS in-process] Low-level exact-position FCS signature help. Returns overloads/parameters around a call site. line/character are 0-based. Pass projectPath/projectOptions and 'text' when available."
                         (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.SignatureHelp args)))
                     |> unwrapResult
                 )
@@ -379,7 +379,7 @@ let main argv =
                 tool (
                     TypedTool.define<PositionArgs>
                         "fsharp_signature_data"
-                        "Structured FSAC signature help via fsharp/signatureData. Requires set_project and an exact call-site position. Use this when FCS fallback is insufficient or when validating FSAC's current workspace view."
+                        "[FSAC] Structured FSAC signature help via fsharp/signatureData. Requires set_project and an exact call-site position. Use this when FCS fallback is insufficient or when validating FSAC's current workspace view."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.SignatureData args)))
                     |> unwrapResult
                 )
@@ -387,7 +387,7 @@ let main argv =
                 tool (
                     TypedTool.define<FormattingArgs>
                         "textDocument_formatting"
-                        "Raw LSP formatting proxy via fsautocomplete/Fantomas. Requires set_project first. Returns formatted text and edits; it does not write to disk. Pass 'text' for unsaved content."
+                        "[FSAC] Raw LSP formatting proxy via fsautocomplete/Fantomas. Requires set_project first. Returns formatted text and edits; it does not write to disk. Pass 'text' for unsaved content."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.Formatting args)))
                     |> unwrapResult
                 )
@@ -395,7 +395,7 @@ let main argv =
                 tool (
                     TypedTool.define<CodeActionArgs>
                         "textDocument_codeAction"
-                        "Raw LSP codeAction proxy at an exact position with empty diagnostic context. Requires set_project first. Useful for debugging FSAC; prefer future diagnostics-to-fix workflows for agent repairs. Pass 'text' for unsaved content."
+                        "[FSAC] Raw LSP codeAction proxy at an exact position with empty diagnostic context. Requires set_project first. Useful for debugging FSAC; prefer future diagnostics-to-fix workflows for agent repairs. Pass 'text' for unsaved content."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.CodeAction args)))
                     |> unwrapResult
                 )
@@ -403,7 +403,7 @@ let main argv =
                 tool (
                     TypedTool.define<RenameArgs>
                         "textDocument_rename"
-                        "Raw LSP semantic rename at an exact position. Requires set_project first. Safer than text search, but returns raw WorkspaceEdit and needs a precise target. Pass 'text' for unsaved content."
+                        "[FSAC] Raw LSP semantic rename at an exact position. Requires set_project first. Safer than text search, but returns raw WorkspaceEdit and needs a precise target. Pass 'text' for unsaved content."
                         (fun args -> toolResult (runLimited lspGate (fun () -> bridge.Rename args)))
                     |> unwrapResult
                 )
@@ -411,7 +411,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsGetProjectOptionsArgs>
                         "fcs_get_project_options"
-                        "Diagnostic helper: get FSharp compiler OtherOptions for a .fsproj via proj-info. Useful when automatic project resolution fails or when passing explicit projectOptions to FCS tools."
+                        "[FCS in-process] Diagnostic helper: get FSharp compiler OtherOptions for a .fsproj via proj-info. Useful when automatic project resolution fails or when passing explicit projectOptions to FCS tools."
                         (fun args ->
                             let path = args.projectPath
 

--- a/ProjectHealth.fs
+++ b/ProjectHealth.fs
@@ -233,15 +233,18 @@ let createReport
 
         match resolveHealthProjectPath args.projectPath with
         | Error reason ->
+            let blockedAxis r =
+                jobj [ "status", jstr "blocked"; "reason", jstr r ] :> JsonNode
+
             return
                 jobj
                     [ "status", jstr "ok"
                       "reportKind", jstr "project"
                       "toolingReadiness",
                       jobj
-                          [ "status", jstr "blocked"
-                            "blockers", JsonArray(jstr reason) :> JsonNode
-                            "recovery", JsonArray(jstr "Pass an explicit .fsproj path to project_health.") :> JsonNode ]
+                          [ "fcs", blockedAxis reason
+                            "lsp", blockedAxis reason
+                            "overall", jstr "blocked" ]
                       "compileStatus", jobj [ "status", jstr "not_checked" ]
                       "project",
                       jobj
@@ -251,15 +254,20 @@ let createReport
         | Ok projectPath ->
             match tryReadProject projectPath with
             | Error reason ->
+                let blockedAxis r =
+                    jobj [ "status", jstr "blocked"; "reason", jstr r ] :> JsonNode
+
+                let readReason = $"Project file cannot be read: %s{reason}"
+
                 return
                     jobj
                         [ "status", jstr "ok"
                           "reportKind", jstr "project"
                           "toolingReadiness",
                           jobj
-                              [ "status", jstr "blocked"
-                                "blockers", JsonArray(jstr $"Project file cannot be read: %s{reason}") :> JsonNode
-                                "recovery", JsonArray(jstr "Fix or restore the project file.") :> JsonNode ]
+                              [ "fcs", blockedAxis readReason
+                                "lsp", blockedAxis readReason
+                                "overall", jstr "blocked" ]
                           "compileStatus", jobj [ "status", jstr "not_checked" ]
                           "project", jobj [ "projectPath", jstr projectPath; "exists", jbool true ] ]
                     :> JsonNode
@@ -321,9 +329,10 @@ let createReport
 
                 let overallStatus =
                     match fcsStatus, lspStatus with
-                    | "ready", "ready" -> "ready"
-                    | ("ready" | "degraded"), _ when fcsStatus <> "blocked" -> "fcs_only"
-                    | _ -> "degraded"
+                    | "ready",   "ready"     -> "ready"
+                    | "ready",   "not_ready" -> "fcs_only"
+                    | "blocked", _           -> "blocked"
+                    | _                      -> "degraded"
 
                 let readiness =
                     jobj

--- a/ProjectHealth.fs
+++ b/ProjectHealth.fs
@@ -284,30 +284,52 @@ let createReport
                             return jobj [ "status", jstr "unavailable"; "reason", jstr reason ] :> JsonNode
                     }
 
-                let warnings = ResizeArray<JsonNode>()
-
-                if not lspSnapshot.WorkspaceReady then
-                    warnings.Add(jstr "LSP workspace is not initialized or not ready.")
+                let fcsWarnings = ResizeArray<JsonNode>()
 
                 if hasMissingFiles || hasUnreadableFiles then
-                    warnings.Add(jstr "Some project source files are missing or unreadable.")
+                    fcsWarnings.Add(jstr "Some project source files are missing or unreadable.")
 
                 match projectOptionsHealth["status"].GetValue<string>() with
                 | "available" -> ()
-                | _ -> warnings.Add(jstr "Project options are unavailable; semantic tools may be incomplete.")
+                | _ -> fcsWarnings.Add(jstr "Project options are unavailable; semantic tools may be incomplete.")
 
-                let readiness =
+                let fcsReadiness =
                     if hasMissingFiles || hasUnreadableFiles then
                         jobj
                             [ "status", jstr "blocked"
                               "blockers", fileSummary["missingFiles"].DeepClone()
                               "recovery", JsonArray(jstr "Restore or materialize required source files.") :> JsonNode ]
-                    elif warnings.Count > 0 then
+                    elif fcsWarnings.Count > 0 then
                         jobj
                             [ "status", jstr "degraded"
-                              "warnings", JsonArray(warnings.ToArray()) :> JsonNode ]
+                              "warnings", JsonArray(fcsWarnings.ToArray()) :> JsonNode ]
                     else
                         jobj [ "status", jstr "ready"; "warnings", JsonArray() :> JsonNode ]
+
+                let lspReadiness =
+                    if lspSnapshot.WorkspaceReady then
+                        jobj [ "status", jstr "ready" ]
+                    else
+                        jobj
+                            [ "status", jstr "not_ready"
+                              "reason",
+                              jstr
+                                  "workspace not initialized; auto-warmed on first textDocument_*/workspace_* call" ]
+
+                let fcsStatus = fcsReadiness["status"].GetValue<string>()
+                let lspStatus = lspReadiness["status"].GetValue<string>()
+
+                let overallStatus =
+                    match fcsStatus, lspStatus with
+                    | "ready", "ready" -> "ready"
+                    | ("ready" | "degraded"), _ when fcsStatus <> "blocked" -> "fcs_only"
+                    | _ -> "degraded"
+
+                let readiness =
+                    jobj
+                        [ "fcs", fcsReadiness :> JsonNode
+                          "lsp", lspReadiness :> JsonNode
+                          "overall", jstr overallStatus ]
 
                 let analyzers = analyzerPackages doc
                 let analyzerConfigFiles = findAnalyzerConfigFiles projectDir

--- a/tests/FsLangMcp.Tests/FcsBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/FcsBridgeTests.fs
@@ -673,3 +673,70 @@ let ``fcs_file_symbols returns InvalidArgument error when path does not exist`` 
         Assert.Equal("InvalidArgument", result["errorKind"].GetValue<string>())
         Assert.Contains("fcs_file_symbols", result["message"].GetValue<string>())
     }
+
+// ─── Regression: validateSourcePath unsaved-buffer workflow (#77 VERIFY) ─────
+
+[<Fact>]
+let ``fcs_parse_and_check_file bypasses File.Exists gate when non-empty text is supplied`` () : Task =
+    // Finding 1: a synthetic-buffer call (path does not exist on disk, text is supplied)
+    // must NOT return InvalidArgument — FCS should use the supplied text.
+    task {
+        let bridge = FcsBridge()
+        let syntheticPath = Path.Combine(Path.GetTempPath(), $"synthetic_%O{Guid.NewGuid()}.fs")
+
+        let! result =
+            bridge.ParseAndCheckFile(
+                { path = syntheticPath
+                  text = Some "module Foo\nlet x = 1"
+                  projectPath = None
+                  projectOptions = None }
+            )
+
+        // Must not return an InvalidArgument error due to the missing file.
+        let status = (result["status"]).GetValue<string>()
+        Assert.NotEqual<string>("error", status)
+    }
+
+[<Fact>]
+let ``fcs_file_outline bypasses File.Exists gate when non-empty text is supplied`` () : Task =
+    // Finding 1: directory rejection still fires even when text is supplied.
+    task {
+        let bridge = FcsBridge()
+        let syntheticPath = Path.Combine(Path.GetTempPath(), $"synthetic_%O{Guid.NewGuid()}.fs")
+
+        let! result =
+            bridge.FileOutline(
+                { path = syntheticPath
+                  text = Some "module Bar\nlet y = 2"
+                  projectPath = None
+                  projectOptions = None
+                  includePrivate = None
+                  includeLocal = None
+                  maxResults = None }
+            )
+
+        let status = (result["status"]).GetValue<string>()
+        Assert.NotEqual<string>("error", status)
+    }
+
+[<Fact>]
+let ``fcs_file_outline still rejects a directory path even when text is supplied`` () : Task =
+    // Finding 1: the directory guard must remain active even with a non-empty text buffer.
+    task {
+        let bridge = FcsBridge()
+        let dir = Path.GetTempPath()
+
+        let! result =
+            bridge.FileOutline(
+                { path = dir
+                  text = Some "module Ignored"
+                  projectPath = None
+                  projectOptions = None
+                  includePrivate = None
+                  includeLocal = None
+                  maxResults = None }
+            )
+
+        Assert.Equal("error", result["status"].GetValue<string>())
+        Assert.Equal("InvalidArgument", result["errorKind"].GetValue<string>())
+    }

--- a/tests/FsLangMcp.Tests/FcsBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/FcsBridgeTests.fs
@@ -579,3 +579,97 @@ let ``fcs_project_outline returns filtered per file outline`` () : Task =
             if Directory.Exists(tempRoot) then
                 Directory.Delete(tempRoot, true)
     }
+
+// ─── Part A: path validation tests ────────────────────────────────────────────
+
+[<Fact>]
+let ``fcs_find_symbol returns InvalidArgument error when path is a directory`` () : Task =
+    task {
+        let bridge = FcsBridge()
+        let dir = Path.GetTempPath() // always exists as a directory
+
+        let! result =
+            bridge.FindSymbol(
+                { path = dir
+                  text = None
+                  projectPath = None
+                  projectOptions = None
+                  symbolQuery = "anySymbol"
+                  exact = Some false
+                  maxResults = Some 10
+                  contextLines = Some 0
+                  includeDeclaration = Some true }
+            )
+
+        Assert.Equal("error", result["status"].GetValue<string>())
+        Assert.Equal("InvalidArgument", result["errorKind"].GetValue<string>())
+        Assert.Contains("not a directory", result["message"].GetValue<string>())
+        Assert.Contains("fcs_find_symbol", result["message"].GetValue<string>())
+    }
+
+[<Fact>]
+let ``fcs_find_symbol returns InvalidArgument error when path does not exist`` () : Task =
+    task {
+        let bridge = FcsBridge()
+        let missing = Path.Combine(Path.GetTempPath(), $"does_not_exist_%O{Guid.NewGuid()}.fs")
+
+        let! result =
+            bridge.FindSymbol(
+                { path = missing
+                  text = None
+                  projectPath = None
+                  projectOptions = None
+                  symbolQuery = "anySymbol"
+                  exact = Some false
+                  maxResults = Some 10
+                  contextLines = Some 0
+                  includeDeclaration = Some true }
+            )
+
+        Assert.Equal("error", result["status"].GetValue<string>())
+        Assert.Equal("InvalidArgument", result["errorKind"].GetValue<string>())
+        Assert.Contains("does not exist or is not readable", result["message"].GetValue<string>())
+    }
+
+[<Fact>]
+let ``fcs_file_outline returns InvalidArgument error when path is a directory`` () : Task =
+    task {
+        let bridge = FcsBridge()
+        let dir = Path.GetTempPath()
+
+        let! result =
+            bridge.FileOutline(
+                { path = dir
+                  text = None
+                  projectPath = None
+                  projectOptions = None
+                  includePrivate = None
+                  includeLocal = None
+                  maxResults = None }
+            )
+
+        Assert.Equal("error", result["status"].GetValue<string>())
+        Assert.Equal("InvalidArgument", result["errorKind"].GetValue<string>())
+        Assert.Contains("fcs_file_outline", result["message"].GetValue<string>())
+    }
+
+[<Fact>]
+let ``fcs_file_symbols returns InvalidArgument error when path does not exist`` () : Task =
+    task {
+        let bridge = FcsBridge()
+        let missing = Path.Combine(Path.GetTempPath(), $"does_not_exist_%O{Guid.NewGuid()}.fs")
+
+        let! result =
+            bridge.FileSymbols(
+                { path = missing
+                  text = None
+                  projectPath = None
+                  projectOptions = None
+                  includeAllUses = None
+                  maxResults = None }
+            )
+
+        Assert.Equal("error", result["status"].GetValue<string>())
+        Assert.Equal("InvalidArgument", result["errorKind"].GetValue<string>())
+        Assert.Contains("fcs_file_symbols", result["message"].GetValue<string>())
+    }

--- a/tests/FsLangMcp.Tests/ProjectHealthTests.fs
+++ b/tests/FsLangMcp.Tests/ProjectHealthTests.fs
@@ -65,7 +65,8 @@ let ``project_health reports source files and analyzer setup`` () =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
         Assert.Equal("ok", (result["status"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["status"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
         Assert.Equal(1, (result["files"]["sourceFileCount"]).GetValue<int>())
         Assert.Equal("analyzers_configured", (result["analyzers"]["status"]).GetValue<string>())
         Assert.Equal("available", (result["projectOptions"]["status"]).GetValue<string>())
@@ -117,7 +118,7 @@ let ``project_health blocks missing compile file`` () =
         let result =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
-        Assert.Equal("blocked", (result["toolingReadiness"]["status"]).GetValue<string>())
+        Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
         Assert.Equal(1, (result["files"]["missingFiles"]).AsArray().Count)
     finally
         if Directory.Exists root then
@@ -149,14 +150,15 @@ let ``project_health reports no analyzers as capability fact`` () =
         let result =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
-        Assert.Equal("ready", (result["toolingReadiness"]["status"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
         Assert.Equal("no_analyzers_configured", (result["analyzers"]["status"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)
 
 [<Fact>]
-let ``project_health degrades when lsp workspace is not ready`` () =
+let ``project_health reports fcs_only overall when lsp workspace is not ready but fcs is fine`` () =
     let runId = System.Guid.NewGuid().ToString("N")
     let root = Path.Combine(Path.GetTempPath(), $"fslangmcp_health_lsp_%s{runId}")
 
@@ -171,7 +173,28 @@ let ``project_health degrades when lsp workspace is not ready`` () =
 
         let result = report (healthArgs projectPath (Some root)) snapshot
 
-        Assert.Equal("degraded", (result["toolingReadiness"]["status"]).GetValue<string>())
+        // FCS axis is healthy; LSP not ready — overall should be fcs_only (not degraded)
+        Assert.Equal("fcs_only", (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("not_ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+    finally
+        if Directory.Exists root then
+            Directory.Delete(root, true)
+
+[<Fact>]
+let ``project_health reports ready overall when both fcs and lsp are ready`` () =
+    let runId = System.Guid.NewGuid().ToString("N")
+    let root = Path.Combine(Path.GetTempPath(), $"fslangmcp_health_both_ready_%s{runId}")
+
+    try
+        let projectPath = writeProject root
+
+        let result =
+            report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
+
+        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)

--- a/tests/FsLangMcp.Tests/ProjectHealthTests.fs
+++ b/tests/FsLangMcp.Tests/ProjectHealthTests.fs
@@ -84,7 +84,9 @@ let ``project_health blocks missing explicit fsproj`` () =
     let result = report args snapshot
 
     Assert.Equal("ok", (result["status"]).GetValue<string>())
-    Assert.Equal("blocked", (result["toolingReadiness"]["status"]).GetValue<string>())
+    Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
+    Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+    Assert.Equal("blocked", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
 
 [<Fact>]
 let ``project_health blocks directory with multiple fsproj files`` () =
@@ -98,8 +100,9 @@ let ``project_health blocks directory with multiple fsproj files`` () =
 
         let result = report (healthArgs root (Some root)) (readySnapshot root root)
 
-        Assert.Equal("blocked", (result["toolingReadiness"]["status"]).GetValue<string>())
-        Assert.Contains("Multiple .fsproj", ((result["toolingReadiness"]["blockers"])[0]).GetValue<string>())
+        Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Contains("Multiple .fsproj", ((result["toolingReadiness"]["fcs"]["reason"]).GetValue<string>()))
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)
@@ -222,6 +225,91 @@ let ``fsharp_project_inspect reports compile order and package references`` () =
         Assert.Equal("implementation", firstCompileFile["kind"].GetValue<string>())
         Assert.Equal(1, (result["filterSummary"]["includedFiles"]).GetValue<int>())
         Assert.True((result["references"]["packageReferences"] :?> JsonArray).Count >= 1)
+    finally
+        if Directory.Exists root then
+            Directory.Delete(root, true)
+
+// ─── Regression tests for VERIFY findings on #77 (closes #81) ────────────────
+
+[<Fact>]
+let ``project_health emits nested fcs/lsp/overall shape when project path does not exist`` () =
+    // Finding 2: early-exit paths must emit the same nested toolingReadiness shape as the
+    // success path, not the old flat {status, blockers, recovery} shape.
+    let runId = System.Guid.NewGuid().ToString("N")
+    let missingProject = Path.Combine(Path.GetTempPath(), $"missing_%s{runId}.fsproj")
+
+    let args = healthArgs missingProject None
+    let snapshot = readySnapshot missingProject (Path.GetTempPath())
+    let result = report args snapshot
+
+    Assert.Equal("ok", (result["status"]).GetValue<string>())
+    Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
+    Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+    Assert.Equal("blocked", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+    // The flat shape keys must NOT be present at the toolingReadiness root
+    Assert.Null(result["toolingReadiness"]["blockers"])
+    Assert.Null(result["toolingReadiness"]["status"])
+
+[<Fact>]
+let ``overallStatus is blocked when fcs is blocked and lsp is ready`` () =
+    // Finding 3: "blocked" FCS axis must propagate to "blocked" overall, not "degraded".
+    let runId = System.Guid.NewGuid().ToString("N")
+
+    let root =
+        Path.Combine(Path.GetTempPath(), $"fslangmcp_health_fcs_blocked_%s{runId}")
+
+    try
+        // Create a project with a missing compile file so fcs status = "blocked".
+        let projectPath = writeProject root
+        File.Delete(Path.Combine(root, "Library.fs"))
+
+        let result =
+            report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
+
+        Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("ready",   (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+        Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
+    finally
+        if Directory.Exists root then
+            Directory.Delete(root, true)
+
+[<Fact>]
+let ``overallStatus is fcs_only when fcs is ready and lsp is not_ready`` () =
+    // Finding 3: fcs=ready + lsp=not_ready must yield "fcs_only" (not "degraded" or "ready").
+    let runId = System.Guid.NewGuid().ToString("N")
+    let root = Path.Combine(Path.GetTempPath(), $"fslangmcp_health_fcs_only_%s{runId}")
+
+    try
+        let projectPath = writeProject root
+
+        let snapshot =
+            { ProjectPath = Some projectPath
+              WorkspaceRoot = Some root
+              WorkspaceReady = false
+              DiagnosticsFileCount = 0 }
+
+        let result = report (healthArgs projectPath (Some root)) snapshot
+
+        Assert.Equal("ready",     (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("not_ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+        Assert.Equal("fcs_only",  (result["toolingReadiness"]["overall"]).GetValue<string>())
+    finally
+        if Directory.Exists root then
+            Directory.Delete(root, true)
+
+[<Fact>]
+let ``overallStatus is ready when both fcs and lsp are ready`` () =
+    // Finding 3: "ready" + "ready" must yield "ready".
+    let runId = System.Guid.NewGuid().ToString("N")
+    let root = Path.Combine(Path.GetTempPath(), $"fslangmcp_health_both_%s{runId}")
+
+    try
+        let projectPath = writeProject root
+        let result = report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
+
+        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)

--- a/tests/FsLangMcp.Tests/ProjectHealthTests.fs
+++ b/tests/FsLangMcp.Tests/ProjectHealthTests.fs
@@ -65,8 +65,8 @@ let ``project_health reports source files and analyzer setup`` () =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
         Assert.Equal("ok", (result["status"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("ready", ((result["toolingReadiness"])["overall"]).GetValue<string>())
+        Assert.Equal("ready", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
         Assert.Equal(1, (result["files"]["sourceFileCount"]).GetValue<int>())
         Assert.Equal("analyzers_configured", (result["analyzers"]["status"]).GetValue<string>())
         Assert.Equal("available", (result["projectOptions"]["status"]).GetValue<string>())
@@ -84,9 +84,9 @@ let ``project_health blocks missing explicit fsproj`` () =
     let result = report args snapshot
 
     Assert.Equal("ok", (result["status"]).GetValue<string>())
-    Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
-    Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-    Assert.Equal("blocked", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+    Assert.Equal("blocked", ((result["toolingReadiness"])["overall"]).GetValue<string>())
+    Assert.Equal("blocked", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+    Assert.Equal("blocked", (((result["toolingReadiness"])["lsp"])["status"]).GetValue<string>())
 
 [<Fact>]
 let ``project_health blocks directory with multiple fsproj files`` () =
@@ -100,9 +100,9 @@ let ``project_health blocks directory with multiple fsproj files`` () =
 
         let result = report (healthArgs root (Some root)) (readySnapshot root root)
 
-        Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
-        Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-        Assert.Contains("Multiple .fsproj", ((result["toolingReadiness"]["fcs"]["reason"]).GetValue<string>()))
+        Assert.Equal("blocked", ((result["toolingReadiness"])["overall"]).GetValue<string>())
+        Assert.Equal("blocked", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+        Assert.Contains("Multiple .fsproj", ((((result["toolingReadiness"])["fcs"])["reason"]).GetValue<string>()))
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)
@@ -121,7 +121,7 @@ let ``project_health blocks missing compile file`` () =
         let result =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
-        Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("blocked", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
         Assert.Equal(1, (result["files"]["missingFiles"]).AsArray().Count)
     finally
         if Directory.Exists root then
@@ -153,8 +153,8 @@ let ``project_health reports no analyzers as capability fact`` () =
         let result =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
-        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
+        Assert.Equal("ready", ((result["toolingReadiness"])["overall"]).GetValue<string>())
+        Assert.Equal("ready", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
         Assert.Equal("no_analyzers_configured", (result["analyzers"]["status"]).GetValue<string>())
     finally
         if Directory.Exists root then
@@ -177,9 +177,9 @@ let ``project_health reports fcs_only overall when lsp workspace is not ready bu
         let result = report (healthArgs projectPath (Some root)) snapshot
 
         // FCS axis is healthy; LSP not ready — overall should be fcs_only (not degraded)
-        Assert.Equal("fcs_only", (result["toolingReadiness"]["overall"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-        Assert.Equal("not_ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+        Assert.Equal("fcs_only", ((result["toolingReadiness"])["overall"]).GetValue<string>())
+        Assert.Equal("ready", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+        Assert.Equal("not_ready", (((result["toolingReadiness"])["lsp"])["status"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)
@@ -195,9 +195,9 @@ let ``project_health reports ready overall when both fcs and lsp are ready`` () 
         let result =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
-        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+        Assert.Equal("ready", ((result["toolingReadiness"])["overall"]).GetValue<string>())
+        Assert.Equal("ready", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+        Assert.Equal("ready", (((result["toolingReadiness"])["lsp"])["status"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)
@@ -243,9 +243,9 @@ let ``project_health emits nested fcs/lsp/overall shape when project path does n
     let result = report args snapshot
 
     Assert.Equal("ok", (result["status"]).GetValue<string>())
-    Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
-    Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-    Assert.Equal("blocked", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
+    Assert.Equal("blocked", ((result["toolingReadiness"])["overall"]).GetValue<string>())
+    Assert.Equal("blocked", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+    Assert.Equal("blocked", (((result["toolingReadiness"])["lsp"])["status"]).GetValue<string>())
     // The flat shape keys must NOT be present at the toolingReadiness root
     Assert.Null(result["toolingReadiness"]["blockers"])
     Assert.Null(result["toolingReadiness"]["status"])
@@ -266,9 +266,9 @@ let ``overallStatus is blocked when fcs is blocked and lsp is ready`` () =
         let result =
             report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
-        Assert.Equal("blocked", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-        Assert.Equal("ready",   (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
-        Assert.Equal("blocked", (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("blocked", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+        Assert.Equal("ready",   (((result["toolingReadiness"])["lsp"])["status"]).GetValue<string>())
+        Assert.Equal("blocked", ((result["toolingReadiness"])["overall"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)
@@ -290,9 +290,9 @@ let ``overallStatus is fcs_only when fcs is ready and lsp is not_ready`` () =
 
         let result = report (healthArgs projectPath (Some root)) snapshot
 
-        Assert.Equal("ready",     (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-        Assert.Equal("not_ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
-        Assert.Equal("fcs_only",  (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("ready",     (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+        Assert.Equal("not_ready", (((result["toolingReadiness"])["lsp"])["status"]).GetValue<string>())
+        Assert.Equal("fcs_only",  ((result["toolingReadiness"])["overall"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)
@@ -307,9 +307,9 @@ let ``overallStatus is ready when both fcs and lsp are ready`` () =
         let projectPath = writeProject root
         let result = report (healthArgs projectPath (Some root)) (readySnapshot projectPath root)
 
-        Assert.Equal("ready", (result["toolingReadiness"]["fcs"]["status"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["lsp"]["status"]).GetValue<string>())
-        Assert.Equal("ready", (result["toolingReadiness"]["overall"]).GetValue<string>())
+        Assert.Equal("ready", (((result["toolingReadiness"])["fcs"])["status"]).GetValue<string>())
+        Assert.Equal("ready", (((result["toolingReadiness"])["lsp"])["status"]).GetValue<string>())
+        Assert.Equal("ready", ((result["toolingReadiness"])["overall"]).GetValue<string>())
     finally
         if Directory.Exists root then
             Directory.Delete(root, true)


### PR DESCRIPTION
## Summary

Three small, independent agent-UX improvements filed together because each is <100 LOC and shares a "clearer agent-facing contracts" theme. Closes #77 and rolls in #81 (a related shape inconsistency surfaced during review).

- **A — `fcs_find_symbol` argument validation**: when `path` is a directory or unreadable, returns a structured `InvalidArgument` with a clear message instead of the cryptic `"Access … denied"`. Same treatment applied at all 8 FCS tool sites that take a `path` arg meaning "anchor file". When the caller supplies non-empty `text`, the `File.Exists` gate is bypassed (preserves the unsaved-buffer workflow); the `Directory.Exists` rejection is kept.
- **B — `project_health` axis split**: `toolingReadiness` is restructured into `{fcs, lsp, overall}`. `overall = "fcs_only"` is a *positive* value meaning "everything an FCS-only agent needs is fine"; `degraded` is reserved for cases where FCS itself is broken. Both happy-path and early-exit paths emit the new shape (closes #81).
- **C — Engine labels in tool descriptions**: every tool's `description` is prefixed with `[FCS in-process]` or `[FSAC]` so agents can plan calls without round-tripping a `set_project` warm-up.

## Verification

- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: 73 passed (61 baseline + 12 new across all three parts).
- Two independent reviews + one closure re-verification:
  - **Code reviewer (initial)**: NEEDS WORK — flagged the unsaved-buffer regression and the `ProjectHealth` shape mismatch.
  - **RealityChecker (initial)**: OK WITH CAVEATS — flagged LSP-side path validation gap (out of scope per issue body) and symlink edge case.
  - **RealityChecker (closure)**: OK — all prior findings closed by named tests at FcsBridgeTests.fs:680/700/723 and ProjectHealthTests.fs:236-251/254/277/301.

## Files changed

| File | Change |
|---|---|
| `FcsBridge.fs` | `validateSourcePath text` helper applied at 8 FCS tool sites; bypasses `File.Exists` when non-empty `text`, keeps `Directory.Exists` rejection |
| `ProjectHealth.fs` | `toolingReadiness` split into `fcs`/`lsp`/`overall` axes on **all** exit paths (success + 2 early-exits); corrected `overallStatus` match table |
| `Program.fs` | All 21 tool descriptions prefixed `[FCS in-process]` (fcs_*, fsharp_compile, project_health, fsharp_project_inspect, fcs_get_project_options) or `[FSAC]` (textDocument_*, workspace_*, set_project, fsharp_signature_data) |
| `tests/FcsBridgeTests.fs` | +7 tests: directory rejection (3 sites), unsaved-buffer bypass (2 sites), missing-file rejection (2 sites) |
| `tests/ProjectHealthTests.fs` | +5 new + 2 updated: nested-shape happy path, `fcs_only`/`ready` overall, early-exit nested shape, blocked-fcs propagation |

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 73/73 passing
- [x] Code review (initial NEEDS WORK → closed by fix commit)
- [x] Reality check (initial caveats + closure OK)
- [ ] Manual smoke: agent calls `fcs_find_symbol` with a directory path → sees clear InvalidArgument; agent calls `project_health` on an FCS-only project → sees `overall: "fcs_only"` not `"degraded"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)