### PR TITLE
feat(outline): conservative defaults + cursor pagination + filter (closes #78)

### DIFF
--- a/Cursor.fs
+++ b/Cursor.fs
@@ -1,0 +1,79 @@
+/// Opaque cursor for stable, offset-based pagination of large tool results.
+///
+/// Design:
+///   - Wire format: Base64(UTF-8 JSON) — opaque to callers, no construction required.
+///   - Internal payload: {"offset": N} — integer byte offset into a deterministic (sorted) list.
+///   - Malformed cursors yield a structured error; callers must treat the value as opaque.
+///   - Consistent with the MCP list-pagination pattern used by resources/list and prompts/list.
+module FsLangMcp.Cursor
+
+open System
+open System.Text
+open System.Text.Json
+open System.Text.Json.Nodes
+
+// ─── Payload ──────────────────────────────────────────────────────────────────
+
+[<Struct>]
+type CursorPayload = { offset: int }
+
+// ─── Encode ───────────────────────────────────────────────────────────────────
+
+/// Encode an integer offset into an opaque, Base64-encoded cursor string.
+let encode (offset: int) : string =
+    let json = $"""{"{"}"offset":{offset}{"}"}"""
+    Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+
+// ─── Decode ───────────────────────────────────────────────────────────────────
+
+/// Attempt to decode a cursor string. Returns Ok with the payload or Error with a
+/// human-readable message. Agents must not construct cursors; use the value returned
+/// by a prior paginated call.
+let tryDecode (cursor: string) : Result<CursorPayload, string> =
+    if String.IsNullOrWhiteSpace(cursor) then
+        Error "cursor must not be empty"
+    else
+        try
+            let bytes = Convert.FromBase64String(cursor)
+            let json = Encoding.UTF8.GetString(bytes)
+            let doc = JsonDocument.Parse(json)
+            let root = doc.RootElement
+
+            match root.TryGetProperty("offset") with
+            | true, offsetEl ->
+                match offsetEl.ValueKind with
+                | JsonValueKind.Number ->
+                    match offsetEl.TryGetInt32() with
+                    | true, offset when offset >= 0 -> Ok { offset = offset }
+                    | true, _ -> Error "cursor offset must be a non-negative integer"
+                    | false, _ -> Error "cursor offset is not a valid int32"
+                | _ -> Error "cursor 'offset' field must be a JSON number"
+            | false, _ -> Error "cursor JSON is missing required 'offset' field"
+        with
+        | :? FormatException -> Error "cursor is not valid Base64"
+        | :? JsonException as ex -> Error $"cursor payload is not valid JSON: {ex.Message}"
+
+// ─── JSON helpers ─────────────────────────────────────────────────────────────
+
+open FsLangMcp.Types
+
+/// Build the cursor-aware pagination envelope fields.
+/// Returns a list of (name, JsonNode) pairs to be merged into the tool response object.
+let paginationFields
+    (totalCount: int)
+    (pageOffset: int)
+    (pageSize: int)
+    (pageCount: int)
+    : (string * JsonNode) list =
+    let isTruncated = pageOffset + pageCount < totalCount
+    let nextCursorNode: JsonNode =
+        if isTruncated then
+            JsonValue.Create(encode (pageOffset + pageCount))
+        else
+            null
+
+    [ "truncated", jbool isTruncated
+      "nextCursor", nextCursorNode
+      "totalEstimate", jobj [ "files", jint totalCount ]
+      "pageOffset", jint pageOffset
+      "pageSize", jint pageSize ]

--- a/Cursor.fs
+++ b/Cursor.fs
@@ -36,7 +36,7 @@ let tryDecode (cursor: string) : Result<CursorPayload, string> =
         try
             let bytes = Convert.FromBase64String(cursor)
             let json = Encoding.UTF8.GetString(bytes)
-            let doc = JsonDocument.Parse(json)
+            use doc = JsonDocument.Parse(json)
             let root = doc.RootElement
 
             match root.TryGetProperty("offset") with

--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -1094,8 +1094,24 @@ type internal FcsBridge() =
                 match args.filter with
                 | None -> None
                 | Some pattern ->
+                    if pattern.Length > 1024 then
+                        invalidArg (nameof args.filter) $"filter pattern must not exceed 1024 characters (got {pattern.Length})"
+
                     try
-                        Some(System.Text.RegularExpressions.Regex(pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+                        // NonBacktracking eliminates catastrophic-backtracking risk for
+                        // user-supplied patterns like (a+)+$. A 250ms timeout is a belt-
+                        // and-suspenders guard; NonBacktracking should never time out.
+                        let opts =
+                            System.Text.RegularExpressions.RegexOptions.NonBacktracking
+                            ||| System.Text.RegularExpressions.RegexOptions.IgnoreCase
+
+                        Some(
+                            System.Text.RegularExpressions.Regex(
+                                pattern,
+                                opts,
+                                TimeSpan.FromMilliseconds 250.0
+                            )
+                        )
                     with ex ->
                         invalidArg (nameof args.filter) $"Invalid filter regex: %s{ex.Message}"
 
@@ -1108,7 +1124,11 @@ type internal FcsBridge() =
                 let matchesRegex =
                     match filterRegex with
                     | None -> true
-                    | Some rx -> rx.IsMatch(name) || rx.IsMatch(signature)
+                    | Some rx ->
+                        try
+                            rx.IsMatch(name) || rx.IsMatch(signature)
+                        with
+                        | :? System.Text.RegularExpressions.RegexMatchTimeoutException -> false
 
                 let matchesNameContains =
                     match nameContains with
@@ -1229,7 +1249,10 @@ type internal FcsBridge() =
 
                         JsonArray(withCount) :> JsonNode
                     else
-                        JsonArray(filteredEntries) :> JsonNode
+                        // Deep-clone each entry to release ownership from the source
+                        // JsonArray returned by FileOutline — a JsonNode may only have
+                        // one parent, so re-parenting without cloning throws.
+                        JsonArray(filteredEntries |> Array.map (fun e -> e.DeepClone())) :> JsonNode
 
                 fileEntries.Add(
                     jobj

--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -14,6 +14,7 @@ open FSharp.Compiler.EditorServices
 open System.Text.Json
 open System.Text.Json.Nodes
 open FsLangMcp.ProjectFiles
+open FsLangMcp.Cursor
 open Ionide.ProjInfo
 open Ionide.ProjInfo.Types
 
@@ -1059,6 +1060,16 @@ type internal FcsBridge() =
             if not (File.Exists projectPath) then
                 invalidArg (nameof args.projectPath) $"Project file does not exist: %s{projectPath}"
 
+            // ── Decode cursor (fail fast on malformed input) ────────────────────
+            let pageOffset =
+                match args.cursor with
+                | None -> 0
+                | Some cursorStr ->
+                    match Cursor.tryDecode cursorStr with
+                    | Ok payload -> payload.offset
+                    | Error reason ->
+                        invalidArg (nameof args.cursor) $"Invalid cursor: %s{reason}"
+
             let workspaceRoot =
                 args.workspacePath
                 |> Option.map Path.GetFullPath
@@ -1069,18 +1080,74 @@ type internal FcsBridge() =
                 | Ok doc -> doc
                 | Error reason -> raise (InvalidOperationException($"Project file cannot be read: %s{reason}"))
 
+            // ── Conservative defaults (issue #78) ───────────────────────────────
+            // maxFiles=50 and maxResultsPerFile=30 keep responses within typical
+            // 25k–50k token context windows on projects up to ~50 files / 10k LOC.
+            // Callers that previously relied on the effectively-unlimited behaviour
+            // must now opt in via explicit larger values or cursor pagination.
+            let pageSize = args.maxFiles |> Option.defaultValue 50
+            let maxResultsPerFile = args.maxResultsPerFile |> Option.defaultValue 30
+            let summaryOnly = args.summaryOnly |> Option.defaultValue true
+
+            // ── Build regex / substring matchers ───────────────────────────────
+            let filterRegex =
+                match args.filter with
+                | None -> None
+                | Some pattern ->
+                    try
+                        Some(System.Text.RegularExpressions.Regex(pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+                    with ex ->
+                        invalidArg (nameof args.filter) $"Invalid filter regex: %s{ex.Message}"
+
+            let nameContains =
+                args.nameContains
+                |> Option.filter (fun lst -> not lst.IsEmpty)
+
+            // Returns true when the entry name / signature passes the filter.
+            let entryMatchesFilter (name: string) (signature: string) =
+                let matchesRegex =
+                    match filterRegex with
+                    | None -> true
+                    | Some rx -> rx.IsMatch(name) || rx.IsMatch(signature)
+
+                let matchesNameContains =
+                    match nameContains with
+                    | None -> true
+                    | Some fragments ->
+                        fragments
+                        |> List.exists (fun fragment ->
+                            name.Contains(fragment, StringComparison.OrdinalIgnoreCase)
+                            || signature.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+
+                matchesRegex && matchesNameContains
+
+            // ── Enumerate all project files (no MaxFiles cap here — we page manually) ─
             let filterOptions =
                 { defaultFilterOptions Outline with
                     IncludeGenerated = args.includeGeneratedFiles |> Option.defaultValue false
                     IncludeTests = args.includeTests |> Option.defaultValue false
-                    MaxFiles = args.maxFiles }
+                    MaxFiles = None }
 
             let files = compileFiles projectPath doc
-            let filtered = filterProjectFiles workspaceRoot filterOptions files
-            let maxResultsPerFile = args.maxResultsPerFile |> Option.defaultValue 100
+
+            // Sort deterministically by path so cursor offsets are stable.
+            let allFiles =
+                filterProjectFiles workspaceRoot filterOptions files
+                |> fun result ->
+                    { result with
+                        Included = result.Included |> List.sortBy (fun f -> f.Path) }
+
+            let totalFileCount = allFiles.Included.Length
+
+            // ── Apply cursor offset then take pageSize ──────────────────────────
+            let pageFiles =
+                allFiles.Included
+                |> List.skip (min pageOffset totalFileCount)
+                |> List.truncate pageSize
+
             let fileEntries = ResizeArray<JsonNode>()
 
-            for file in filtered.Included do
+            for file in pageFiles do
                 let! outline =
                     this.FileOutline(
                         { path = file.Path
@@ -1092,15 +1159,84 @@ type internal FcsBridge() =
                           maxResults = Some maxResultsPerFile }
                     )
 
+                // Pull raw entries array (may be null if outline aborted).
+                let rawEntries: JsonNode array =
+                    match outline["entries"] with
+                    | null -> [||]
+                    | entries ->
+                        match entries with
+                        | :? JsonArray as arr -> arr |> Seq.cast<JsonNode> |> Seq.toArray
+                        | _ -> [||]
+
+                // Apply filter BEFORE truncation, then apply per-file cap.
+                let filteredEntries =
+                    if filterRegex.IsNone && nameContains.IsNone then
+                        rawEntries |> Array.truncate maxResultsPerFile
+                    else
+                        rawEntries
+                        |> Array.filter (fun entry ->
+                            let name =
+                                match entry["name"] with
+                                | null -> ""
+                                | n -> n.GetValue<string>()
+
+                            let signature =
+                                match entry["signature"] with
+                                | null -> ""
+                                | s -> s.GetValue<string>()
+
+                            entryMatchesFilter name signature)
+                        |> Array.truncate maxResultsPerFile
+
+                // summaryOnly: strip per-member signature detail, keep headers & counts.
+                let outlineEntries: JsonNode =
+                    if summaryOnly then
+                        // Group by "kind" (module/record/union/class/interface) for a
+                        // compact header + member-count summary.
+                        let containerKinds =
+                            [| "module"; "record"; "union"; "class"; "interface"; "enum"; "delegate"; "namespace" |]
+
+                        let topLevel =
+                            filteredEntries
+                            |> Array.filter (fun entry ->
+                                match entry["kind"] with
+                                | null -> false
+                                | k -> containerKinds |> Array.contains (k.GetValue<string>()))
+
+                        let memberCount = filteredEntries.Length - topLevel.Length
+
+                        let summaryNodes =
+                            topLevel
+                            |> Array.map (fun entry ->
+                                jobj
+                                    [ "name", entry["name"].DeepClone()
+                                      "kind", entry["kind"].DeepClone()
+                                      "fullName",
+                                      (match entry["fullName"] with
+                                       | null -> null
+                                       | fn -> fn.DeepClone())
+                                      "range",
+                                      (match entry["range"] with
+                                       | null -> null
+                                       | r -> r.DeepClone()) ]
+                                :> JsonNode)
+
+                        // Append a synthetic _members_count sentinel for LLM context.
+                        let withCount =
+                            Array.append
+                                summaryNodes
+                                [| jobj [ "kind", jstr "_summary"; "memberCount", jint memberCount ] :> JsonNode |]
+
+                        JsonArray(withCount) :> JsonNode
+                    else
+                        JsonArray(filteredEntries) :> JsonNode
+
                 fileEntries.Add(
                     jobj
                         [ "file", jstr file.Path
                           "kind", jstr (if file.IsSignature then "signature" else "implementation")
                           "outlineStatus", outline["status"].DeepClone()
-                          "entries",
-                          (match outline["entries"] with
-                           | null -> JsonArray() :> JsonNode
-                           | entries -> entries.DeepClone())
+                          "entries", outlineEntries
                           "count",
                           (match outline["count"] with
                            | null -> jint 0
@@ -1108,14 +1244,19 @@ type internal FcsBridge() =
                     :> JsonNode
                 )
 
-            return
-                jobj
-                    [ "status", jstr "succeeded"
-                      "projectPath", jstr projectPath
-                      "workspaceRoot", jstr workspaceRoot
-                      "filterSummary", filterSummaryToJson filtered :> JsonNode
-                      "files", JsonArray(fileEntries.ToArray()) :> JsonNode ]
-                :> JsonNode
+            // ── Pagination envelope ─────────────────────────────────────────────
+            let paginationFields =
+                Cursor.paginationFields totalFileCount pageOffset pageSize pageFiles.Length
+
+            let baseFields =
+                [ "status", jstr "ok"
+                  "projectPath", jstr projectPath
+                  "workspaceRoot", jstr workspaceRoot
+                  "summaryOnly", jbool summaryOnly
+                  "filterSummary", filterSummaryToJson allFiles :> JsonNode
+                  "files", JsonArray(fileEntries.ToArray()) :> JsonNode ]
+
+            return jobj (baseFields @ paginationFields) :> JsonNode
         }
 
     member _.ClearCaches() =

--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="BoundedCache.fs" />
     <Compile Include="Types.fs" />
     <Compile Include="ProjectFiles.fs" />
+    <Compile Include="Cursor.fs" />
     <Compile Include="ProjectInspection.fs" />
     <Compile Include="ProjectHealth.fs" />
     <Compile Include="LspBridge.fs" />

--- a/Types.fs
+++ b/Types.fs
@@ -114,8 +114,19 @@ type FcsProjectOutlineArgs =
       includePrivate: bool option
       includeTests: bool option
       includeGeneratedFiles: bool option
+      /// Maximum number of files to include in one page. Default: 50.
       maxFiles: int option
-      maxResultsPerFile: int option }
+      /// Maximum number of symbol entries per file. Default: 30.
+      maxResultsPerFile: int option
+      /// When true (default), return module/type headers + member counts only.
+      /// Set to false to get full per-member signatures (legacy behaviour).
+      summaryOnly: bool option
+      /// Opaque pagination cursor returned by a prior call. Agents must not construct this.
+      cursor: string option
+      /// Regex applied to member names/signatures before truncation.
+      filter: string option
+      /// OR-joined substring list applied to member names before truncation.
+      nameContains: string list option }
 
 type FSharpProjectInspectArgs =
     { projectPath: string

--- a/tests/FsLangMcp.Tests/FcsBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/FcsBridgeTests.fs
@@ -569,10 +569,14 @@ let ``fcs_project_outline returns filtered per file outline`` () : Task =
                       includeTests = None
                       includeGeneratedFiles = None
                       maxFiles = Some 10
-                      maxResultsPerFile = Some 50 }
+                      maxResultsPerFile = Some 50
+                      summaryOnly = None
+                      cursor = None
+                      filter = None
+                      nameContains = None }
                 )
 
-            Assert.Equal("succeeded", result["status"].GetValue<string>())
+            Assert.Equal("ok", result["status"].GetValue<string>())
             Assert.Equal(1, (result["filterSummary"]["includedFiles"]).GetValue<int>())
             Assert.Equal(1, (result["files"] :?> JsonArray).Count)
         finally

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="BoundedCacheTests.fs" />
     <Compile Include="FcsBridgeTests.fs" />
     <Compile Include="OutlinePaginationTests.fs" />
+    <Compile Include="OutlineE2ETests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="../../BoundedCache.fs" Link="BoundedCache.fs" />
     <Compile Include="../../Types.fs" Link="Types.fs" />
     <Compile Include="../../ProjectFiles.fs" Link="ProjectFiles.fs" />
+    <Compile Include="../../Cursor.fs" Link="Cursor.fs" />
     <Compile Include="../../ProjectInspection.fs" Link="ProjectInspection.fs" />
     <Compile Include="../../ProjectHealth.fs" Link="ProjectHealth.fs" />
     <Compile Include="../../LspBridge.fs" Link="LspBridge.fs" />
@@ -21,6 +22,7 @@
     <Compile Include="ProjectHealthTests.fs" />
     <Compile Include="BoundedCacheTests.fs" />
     <Compile Include="FcsBridgeTests.fs" />
+    <Compile Include="OutlinePaginationTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FsLangMcp.Tests/OutlineE2ETests.fs
+++ b/tests/FsLangMcp.Tests/OutlineE2ETests.fs
@@ -213,8 +213,15 @@ let ``ProjectOutline with catastrophic-backtracking pattern completes in under 1
         let bridge = FcsBridge()
 
         try
+            // Warm up FCS: parse the project once without a filter so that
+            // projectResultsCache is populated.  FCS cold-start (JIT + project
+            // compilation) easily takes 1–2 s and must not be charged to the
+            // regex-guard measurement.
+            let! _ = bridge.ProjectOutline({ defaultArgs projectPath with maxFiles = Some 100 })
+
             // (a+)+$ is the canonical catastrophic-backtracking pattern.
             // Against a long-ish string without NonBacktracking this would hang.
+            // The FCS cache is warm, so only regex work is timed here.
             let sw = System.Diagnostics.Stopwatch.StartNew()
 
             let! result =
@@ -227,7 +234,7 @@ let ``ProjectOutline with catastrophic-backtracking pattern completes in under 1
             sw.Stop()
 
             Assert.Equal("ok", result["status"].GetValue<string>())
-            // NonBacktracking makes this instant; assert well under 1 s.
+            // NonBacktracking makes the regex portion instant; assert well under 1 s.
             Assert.True(
                 sw.Elapsed.TotalSeconds < 1.0,
                 $"Pattern (a+)+$ took {sw.Elapsed.TotalMilliseconds:F0}ms — NonBacktracking not applied?"

--- a/tests/FsLangMcp.Tests/OutlineE2ETests.fs
+++ b/tests/FsLangMcp.Tests/OutlineE2ETests.fs
@@ -1,0 +1,333 @@
+module FsLangMcp.Tests.OutlineE2ETests
+
+/// End-to-end integration tests for ProjectOutline (issue #78 fixes).
+///
+/// These tests call FcsBridge.ProjectOutline against a real temp fsproj to
+/// exercise the production filter/pagination code path — not a replicated helper.
+///
+/// Coverage:
+///   F. No filter → all files returned
+///   G. Filter regex → only matching entries pass through
+///   H. Evil pattern (a+)+$ — completes well under 1 s (DoS regression guard)
+///   I. Overlong filter (>1024 chars) → InvalidArgException
+///   J. Cursor pagination round-trip: page-1 has nextCursor + truncated=true;
+///      page-2 with that cursor returns the rest, no overlap
+
+open System
+open System.IO
+open System.Text.Json.Nodes
+open Xunit
+open FsLangMcp.Types
+open FsLangMcp.FcsBridge
+open FsLangMcp.Cursor
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Create a temp directory containing a project with two .fs source files.
+/// File1: module Alpha with a type Timer and a let getValue.
+/// File2: module Beta with a let processData and a type Channel.
+/// Returns (projectPath, tempRoot).
+let private createFixtureProject () =
+    let runId = Guid.NewGuid().ToString("N")
+    let root = Path.Combine(Path.GetTempPath(), $"fslangmcp_outline_e2e_{runId}")
+    Directory.CreateDirectory(root) |> ignore
+
+    // File1.fs — contains "Timer"
+    let file1 = Path.Combine(root, "File1.fs")
+    File.WriteAllText(
+        file1,
+        """module Alpha
+
+type Timer = { interval: int }
+
+let getValue () = 42
+"""
+    )
+
+    // File2.fs — contains "Channel"
+    let file2 = Path.Combine(root, "File2.fs")
+    File.WriteAllText(
+        file2,
+        """module Beta
+
+type Channel = { name: string }
+
+let processData (x: int) = x * 2
+"""
+    )
+
+    let projectPath = Path.Combine(root, "Fixture.fsproj")
+    File.WriteAllText(
+        projectPath,
+        String.concat
+            Environment.NewLine
+            [ "<Project Sdk=\"Microsoft.NET.Sdk\">"
+              "  <PropertyGroup>"
+              "    <TargetFramework>net10.0</TargetFramework>"
+              "  </PropertyGroup>"
+              "  <ItemGroup>"
+              "    <Compile Include=\"File1.fs\" />"
+              "    <Compile Include=\"File2.fs\" />"
+              "  </ItemGroup>"
+              "</Project>" ]
+    )
+
+    projectPath, root
+
+let private defaultArgs projectPath : FcsProjectOutlineArgs =
+    { projectPath = projectPath
+      workspacePath = None
+      includePrivate = None
+      includeTests = None
+      includeGeneratedFiles = None
+      maxFiles = None
+      maxResultsPerFile = None
+      summaryOnly = Some false   // full detail so we can inspect entries
+      cursor = None
+      filter = None
+      nameContains = None }
+
+let private filesArray (result: JsonNode) =
+    result["files"] :?> JsonArray
+
+// ─── F. No filter — all files included ────────────────────────────────────────
+
+[<Fact>]
+let ``ProjectOutline without filter returns all project files`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result = bridge.ProjectOutline({ defaultArgs projectPath with maxFiles = Some 100 })
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+            // We have 2 .fs files; both should be included.
+            Assert.Equal(2, files.Count)
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+// ─── G. Filter regex — only matching entries pass through ─────────────────────
+
+[<Fact>]
+let ``ProjectOutline with filter 'Timer' returns entries matching Timer`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        filter = Some "Timer" }
+                )
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+
+            // At least one file must have entries that match 'Timer'.
+            let hasTimerEntry =
+                files
+                |> Seq.cast<JsonNode>
+                |> Seq.exists (fun file ->
+                    let entries = file["entries"] :?> JsonArray
+
+                    entries
+                    |> Seq.cast<JsonNode>
+                    |> Seq.exists (fun entry ->
+                        match entry["name"] with
+                        | null -> false
+                        | n -> n.GetValue<string>().Contains("Timer", StringComparison.OrdinalIgnoreCase)))
+
+            Assert.True(hasTimerEntry, "Expected at least one 'Timer' entry after filtering")
+
+            // Entries with 'Channel' must NOT appear when filter is 'Timer'.
+            let hasChannelEntry =
+                files
+                |> Seq.cast<JsonNode>
+                |> Seq.exists (fun file ->
+                    let entries = file["entries"] :?> JsonArray
+
+                    entries
+                    |> Seq.cast<JsonNode>
+                    |> Seq.exists (fun entry ->
+                        match entry["name"] with
+                        | null -> false
+                        | n -> n.GetValue<string>().Contains("Channel", StringComparison.OrdinalIgnoreCase)))
+
+            Assert.False(hasChannelEntry, "Channel entries must be excluded when filter is 'Timer'")
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+[<Fact>]
+let ``ProjectOutline with alternation filter 'Timer|Channel' matches both types`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        filter = Some "Timer|Channel" }
+                )
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+
+            let allEntryNames =
+                files
+                |> Seq.cast<JsonNode>
+                |> Seq.collect (fun file ->
+                    (file["entries"] :?> JsonArray)
+                    |> Seq.cast<JsonNode>
+                    |> Seq.choose (fun entry ->
+                        match entry["name"] with
+                        | null -> None
+                        | n -> Some(n.GetValue<string>())))
+                |> Seq.toList
+
+            let hasTimer = allEntryNames |> List.exists (fun n -> n.Contains("Timer", StringComparison.OrdinalIgnoreCase))
+            let hasChannel = allEntryNames |> List.exists (fun n -> n.Contains("Channel", StringComparison.OrdinalIgnoreCase))
+
+            Assert.True(hasTimer, "Expected Timer entry with 'Timer|Channel' filter")
+            Assert.True(hasChannel, "Expected Channel entry with 'Timer|Channel' filter")
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+// ─── H. Evil pattern — must complete in << 1 s (DoS regression guard) ────────
+
+[<Fact>]
+let ``ProjectOutline with catastrophic-backtracking pattern completes in under 1 second`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            // (a+)+$ is the canonical catastrophic-backtracking pattern.
+            // Against a long-ish string without NonBacktracking this would hang.
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        filter = Some "(a+)+$" }
+                )
+
+            sw.Stop()
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+            // NonBacktracking makes this instant; assert well under 1 s.
+            Assert.True(
+                sw.Elapsed.TotalSeconds < 1.0,
+                $"Pattern (a+)+$ took {sw.Elapsed.TotalMilliseconds:F0}ms — NonBacktracking not applied?"
+            )
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+// ─── I. Overlong filter → InvalidArgException ─────────────────────────────────
+
+[<Fact>]
+let ``ProjectOutline with filter longer than 1024 chars throws InvalidArgException`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let overlong = String.replicate 1025 "a"
+
+            // invalidArg inside task{} is captured as a faulted Task; await and unwrap.
+            let! ex =
+                Assert.ThrowsAsync<ArgumentException>(fun () ->
+                    bridge.ProjectOutline({ defaultArgs projectPath with filter = Some overlong })
+                    :> System.Threading.Tasks.Task)
+
+            Assert.Contains("1024", ex.Message)
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+// ─── J. Cursor pagination round-trip ─────────────────────────────────────────
+//
+// Project has 2 files. We call with maxFiles=1 to force pagination.
+// Page 1 → truncated=true, nextCursor is non-null, exactly 1 file returned.
+// Page 2 → using cursor from page 1, truncated=false, returns the remaining file.
+// The two file paths must be disjoint (no overlap).
+
+[<Fact>]
+let ``ProjectOutline cursor pagination: page-1 has nextCursor and page-2 returns disjoint remainder`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            // ── Page 1 ──────────────────────────────────────────────────────────
+            let! page1 =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 1   // force pagination
+                        cursor = None }
+                )
+
+            Assert.Equal("ok", page1["status"].GetValue<string>())
+            Assert.True(page1["truncated"].GetValue<bool>(), "Page 1 must have truncated=true")
+
+            let nextCursorNode = page1["nextCursor"]
+            Assert.NotNull(nextCursorNode)
+            let nextCursor = nextCursorNode.GetValue<string>()
+            Assert.NotEmpty(nextCursor)
+
+            let page1Files =
+                filesArray page1
+                |> Seq.cast<JsonNode>
+                |> Seq.map (fun f -> f["file"].GetValue<string>())
+                |> Set.ofSeq
+
+            Assert.Equal(1, page1Files.Count)
+
+            // Cursor must decode correctly.
+            match tryDecode nextCursor with
+            | Error msg -> Assert.Fail($"nextCursor did not decode: {msg}")
+            | Ok payload -> Assert.Equal(1, payload.offset)
+
+            // ── Page 2 ──────────────────────────────────────────────────────────
+            let! page2 =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 1
+                        cursor = Some nextCursor }
+                )
+
+            Assert.Equal("ok", page2["status"].GetValue<string>())
+            Assert.False(page2["truncated"].GetValue<bool>(), "Page 2 must have truncated=false (last page)")
+            Assert.Null(page2["nextCursor"])
+
+            let page2Files =
+                filesArray page2
+                |> Seq.cast<JsonNode>
+                |> Seq.map (fun f -> f["file"].GetValue<string>())
+                |> Set.ofSeq
+
+            Assert.Equal(1, page2Files.Count)
+
+            // No overlap between pages.
+            let overlap = Set.intersect page1Files page2Files
+            Assert.Empty(overlap)
+
+            // Together they cover both project files.
+            let combined = Set.union page1Files page2Files
+            Assert.Equal(2, combined.Count)
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }

--- a/tests/FsLangMcp.Tests/OutlinePaginationTests.fs
+++ b/tests/FsLangMcp.Tests/OutlinePaginationTests.fs
@@ -1,0 +1,278 @@
+module FsLangMcp.Tests.OutlinePaginationTests
+
+/// Unit tests for the cursor pagination + filter features added in issue #78.
+///
+/// Coverage:
+///   A. Cursor encode / decode round-trip
+///   B. Cursor rejects malformed input (structured error, not exception)
+///   C. paginationFields produces correct truncated / nextCursor / totalEstimate
+///   D. Filter regex — entry matching
+///   E. Default args shape (summaryOnly=true, maxFiles=50, maxResultsPerFile=30)
+
+open System
+open System.Text
+open System.Text.Json
+open System.Text.Json.Nodes
+open Xunit
+open FsLangMcp.Cursor
+open FsLangMcp.Types
+
+// ─── A. Cursor round-trip ──────────────────────────────────────────────────────
+
+[<Fact>]
+let ``encode then tryDecode round-trips offset zero`` () =
+    let cursor = encode 0
+    match tryDecode cursor with
+    | Ok payload -> Assert.Equal(0, payload.offset)
+    | Error msg -> Assert.Fail($"Expected Ok but got Error: {msg}")
+
+[<Fact>]
+let ``encode then tryDecode round-trips arbitrary positive offset`` () =
+    let cursor = encode 87
+    match tryDecode cursor with
+    | Ok payload -> Assert.Equal(87, payload.offset)
+    | Error msg -> Assert.Fail($"Expected Ok but got Error: {msg}")
+
+[<Fact>]
+let ``encode then tryDecode round-trips large offset`` () =
+    let cursor = encode 10_000
+    match tryDecode cursor with
+    | Ok payload -> Assert.Equal(10_000, payload.offset)
+    | Error msg -> Assert.Fail($"Expected Ok but got Error: {msg}")
+
+[<Fact>]
+let ``encode produces a non-empty Base64 string`` () =
+    let cursor = encode 5
+    Assert.NotEmpty(cursor)
+    // Base64 alphabet — no spaces
+    Assert.DoesNotContain(" ", cursor)
+
+[<Fact>]
+let ``encoded cursor is not human-readable JSON (opaque)`` () =
+    let cursor = encode 3
+    // The raw cursor string must not look like a plain JSON object.
+    Assert.False(cursor.StartsWith("{"), "cursor should be Base64, not raw JSON")
+
+// ─── B. Cursor rejects malformed input ────────────────────────────────────────
+
+[<Fact>]
+let ``tryDecode returns Error for empty string`` () =
+    match tryDecode "" with
+    | Error _ -> ()
+    | Ok _ -> Assert.Fail("Expected Error for empty cursor")
+
+[<Fact>]
+let ``tryDecode returns Error for whitespace-only string`` () =
+    match tryDecode "   " with
+    | Error _ -> ()
+    | Ok _ -> Assert.Fail("Expected Error for whitespace cursor")
+
+[<Fact>]
+let ``tryDecode returns Error for non-Base64 garbage`` () =
+    match tryDecode "not-valid-base64!!!" with
+    | Error msg ->
+        Assert.Contains("Base64", msg, StringComparison.OrdinalIgnoreCase)
+    | Ok _ -> Assert.Fail("Expected Error for garbage cursor")
+
+[<Fact>]
+let ``tryDecode returns Error for valid Base64 but not JSON`` () =
+    // Base64 of "hello world"
+    let cursor = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello world"))
+    match tryDecode cursor with
+    | Error _ -> ()
+    | Ok _ -> Assert.Fail("Expected Error for non-JSON payload")
+
+[<Fact>]
+let ``tryDecode returns Error when offset field is missing`` () =
+    let cursor = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"page":1}"""))
+    match tryDecode cursor with
+    | Error msg -> Assert.Contains("offset", msg)
+    | Ok _ -> Assert.Fail("Expected Error when offset field is missing")
+
+[<Fact>]
+let ``tryDecode returns Error when offset is negative`` () =
+    let cursor = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"offset":-1}"""))
+    match tryDecode cursor with
+    | Error msg -> Assert.Contains("non-negative", msg)
+    | Ok _ -> Assert.Fail("Expected Error for negative offset")
+
+[<Fact>]
+let ``tryDecode returns Error when offset is a string`` () =
+    let cursor = Convert.ToBase64String(Encoding.UTF8.GetBytes("""{"offset":"five"}"""))
+    match tryDecode cursor with
+    | Error _ -> ()
+    | Ok _ -> Assert.Fail("Expected Error when offset is a string")
+
+// ─── C. paginationFields ──────────────────────────────────────────────────────
+
+[<Fact>]
+let ``paginationFields truncated=false when all items fit on one page`` () =
+    let fields = paginationFields 10 0 50 10
+    let dict = fields |> Map.ofList
+
+    let truncated = dict["truncated"].GetValue<bool>()
+    Assert.False(truncated)
+
+[<Fact>]
+let ``paginationFields truncated=true when more items remain`` () =
+    let fields = paginationFields 100 0 50 50
+    let dict = fields |> Map.ofList
+
+    let truncated = dict["truncated"].GetValue<bool>()
+    Assert.True(truncated)
+
+[<Fact>]
+let ``paginationFields nextCursor is null when not truncated`` () =
+    let fields = paginationFields 10 0 50 10
+    let dict = fields |> Map.ofList
+
+    Assert.Null(dict["nextCursor"])
+
+[<Fact>]
+let ``paginationFields nextCursor is a non-null string when truncated`` () =
+    let fields = paginationFields 100 0 50 50
+    let dict = fields |> Map.ofList
+
+    let cursor = dict["nextCursor"]
+    Assert.NotNull(cursor)
+    let cursorStr = cursor.GetValue<string>()
+    Assert.NotEmpty(cursorStr)
+
+[<Fact>]
+let ``paginationFields nextCursor offset equals pageOffset plus pageCount`` () =
+    // First page: offset 0, size 50, got 50 items
+    let fields = paginationFields 120 0 50 50
+    let dict = fields |> Map.ofList
+    let cursorStr = dict["nextCursor"].GetValue<string>()
+
+    match tryDecode cursorStr with
+    | Ok payload -> Assert.Equal(50, payload.offset)
+    | Error msg -> Assert.Fail($"nextCursor did not decode: {msg}")
+
+[<Fact>]
+let ``paginationFields second page cursor offset advances correctly`` () =
+    // Second page: offset 50, pageSize 50, got 50 → expect cursor at 100
+    let fields = paginationFields 150 50 50 50
+    let dict = fields |> Map.ofList
+    let cursorStr = dict["nextCursor"].GetValue<string>()
+
+    match tryDecode cursorStr with
+    | Ok payload -> Assert.Equal(100, payload.offset)
+    | Error msg -> Assert.Fail($"nextCursor did not decode: {msg}")
+
+[<Fact>]
+let ``paginationFields totalEstimate files equals totalCount`` () =
+    let fields = paginationFields 87 0 50 50
+    let dict = fields |> Map.ofList
+    let totalEstimate = dict["totalEstimate"]
+    let filesCount = totalEstimate["files"].GetValue<int>()
+    Assert.Equal(87, filesCount)
+
+// ─── D. Filter regex matching (isolated helper simulation) ────────────────────
+
+// The real matching logic lives inside FcsBridge.ProjectOutline, which requires a
+// live FCS project. We test the conceptual behaviour here by replicating the
+// lightweight predicate for isolation — confirming the regex contract independently
+// of the full outline pipeline.
+
+let private matchesRegexFilter (pattern: string) (name: string) (signature: string) =
+    let rx = System.Text.RegularExpressions.Regex(pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase)
+    rx.IsMatch(name) || rx.IsMatch(signature)
+
+[<Fact>]
+let ``filter regex matches on member name`` () =
+    Assert.True(matchesRegexFilter "Timer" "MyTimer" "unit -> unit")
+
+[<Fact>]
+let ``filter regex matches on signature when name does not match`` () =
+    Assert.True(matchesRegexFilter "MailboxProcessor" "runAgent" "MailboxProcessor<int> -> unit")
+
+[<Fact>]
+let ``filter regex is case-insensitive`` () =
+    Assert.True(matchesRegexFilter "mailboxprocessor" "MyMailboxProcessor" "")
+
+[<Fact>]
+let ``filter regex returns false when neither name nor signature matches`` () =
+    Assert.False(matchesRegexFilter "Channel" "openFile" "string -> Result<unit, exn>")
+
+[<Fact>]
+let ``filter alternation regex matches any of the patterns`` () =
+    // Simulates: Event|Timer|MailboxProcessor|Channel|BackgroundService
+    let pattern = "Event|Timer|MailboxProcessor|Channel|BackgroundService"
+    Assert.True(matchesRegexFilter pattern "myTimer" "unit -> unit")
+    Assert.True(matchesRegexFilter pattern "EventLoop" "unit -> unit")
+    Assert.True(matchesRegexFilter pattern "processMsg" "MailboxProcessor<int> -> unit")
+    Assert.False(matchesRegexFilter pattern "doWork" "string -> bool")
+
+// ─── E. Default shape — FcsProjectOutlineArgs ─────────────────────────────────
+
+[<Fact>]
+let ``FcsProjectOutlineArgs all optional fields default to None`` () =
+    // This test confirms the record compiles with None for all new optional fields.
+    // It acts as a compile-time guard: if a required field were accidentally added
+    // without a default, this would fail to compile.
+    let args: FcsProjectOutlineArgs =
+        { projectPath = "/some/project.fsproj"
+          workspacePath = None
+          includePrivate = None
+          includeTests = None
+          includeGeneratedFiles = None
+          maxFiles = None           // default 50 at runtime
+          maxResultsPerFile = None  // default 30 at runtime
+          summaryOnly = None        // default true at runtime
+          cursor = None
+          filter = None
+          nameContains = None }
+
+    Assert.Equal("/some/project.fsproj", args.projectPath)
+    Assert.True(args.summaryOnly.IsNone, "summaryOnly should be None (uses runtime default)")
+    Assert.True(args.maxFiles.IsNone, "maxFiles should be None (uses runtime default of 50)")
+    Assert.True(args.maxResultsPerFile.IsNone, "maxResultsPerFile should be None (runtime default 30)")
+    Assert.True(args.cursor.IsNone)
+    Assert.True(args.filter.IsNone)
+    Assert.True(args.nameContains.IsNone)
+
+[<Fact>]
+let ``FcsProjectOutlineArgs accepts explicit values for all new fields`` () =
+    let args: FcsProjectOutlineArgs =
+        { projectPath = "/some/project.fsproj"
+          workspacePath = None
+          includePrivate = Some true
+          includeTests = Some false
+          includeGeneratedFiles = Some false
+          maxFiles = Some 100
+          maxResultsPerFile = Some 60
+          summaryOnly = Some false
+          cursor = Some (encode 50)
+          filter = Some "Timer|Channel"
+          nameContains = Some [ "Event"; "Timer" ] }
+
+    Assert.Equal(Some 100, args.maxFiles)
+    Assert.Equal(Some 60, args.maxResultsPerFile)
+    Assert.Equal(Some false, args.summaryOnly)
+    Assert.True(args.cursor.IsSome)
+    Assert.Equal(Some "Timer|Channel", args.filter)
+    Assert.Equal(Some [ "Event"; "Timer" ], args.nameContains)
+
+[<Fact>]
+let ``cursor stored in FcsProjectOutlineArgs round-trips correctly`` () =
+    let cursorStr = encode 42
+    let args: FcsProjectOutlineArgs =
+        { projectPath = "/p.fsproj"
+          workspacePath = None
+          includePrivate = None
+          includeTests = None
+          includeGeneratedFiles = None
+          maxFiles = None
+          maxResultsPerFile = None
+          summaryOnly = None
+          cursor = Some cursorStr
+          filter = None
+          nameContains = None }
+
+    match args.cursor with
+    | None -> Assert.Fail("cursor was None")
+    | Some c ->
+        match tryDecode c with
+        | Ok payload -> Assert.Equal(42, payload.offset)
+        | Error msg -> Assert.Fail($"cursor did not decode: {msg}")


### PR DESCRIPTION
## Summary

Closes #78. Adds the official MCP-style pagination contract to `fcs_project_outline` so large structural responses fit a typical agent context window by default and page cleanly via an opaque cursor when they don't.

- **Conservative defaults**: `maxFiles=50`, `maxResultsPerFile=30`, `summaryOnly=true`. Old behavior is opt-in via `summaryOnly=false`.
- **Opaque cursor pagination**: when truncated, response carries `truncated: true`, `nextCursor: \"<base64>\"`, `pageOffset`, `pageSize`, `totalEstimate`. Pass the cursor back to fetch the next page.
- **Filter args**: `filter` (regex, applied with `RegexOptions.NonBacktracking`, 250ms timeout, 1024-char cap) and `nameContains` (substring list, OR-joined) — applied BEFORE truncation so an agent doing a leak audit can cut output 50–500× without overflowing.
- **Reusable `Cursor` module** (`Cursor.fs`): `encode`, `tryDecode`, `paginationFields`. Designed for adoption by `fcs_project_symbol_uses` and `fcs_find_symbol` (tracked as #80).

## Status code

`fcs_project_outline` returns `\"status\": \"ok\"` per the issue's sample shape (was previously `\"succeeded\"`). This is a contract change visible to clients that switch on the status string — call out in changelog when tagging.

## Verification

- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: 94 passing (88 from initial BUILD + 6 e2e tests added in fix wave).
- Two independent reviews + one closure re-verification:
  - **Code reviewer (initial)**: NEEDS WORK — regex DoS via no timeout/NonBacktracking, JsonDocument leak in `Cursor.tryDecode`, tests using replicated helper instead of real code path.
  - **RealityChecker (initial)**: OK WITH CAVEATS — same probes, plus filter-test-coverage gap.
  - **RealityChecker (closure)**: OK — DoS guard verified by timing assertion (`(a+)+\$` against fixture entries completes in <1s); `use doc =` confirmed in Cursor.fs:39; new e2e test at `OutlineE2ETests.fs:276-329` exercises page-1+page-2 reassembly with `Set.intersect = empty` and `Set.union = expected total`.

## Bonus fix

The fix wave's e2e tests surfaced a pre-existing `JsonNode parent` crash in the `summaryOnly=false` path on multi-file projects (every JsonNode has at most one parent; the original code referenced entries from two output trees). Resolved via deep-clone in this PR.

## Discovered follow-ups (filed separately, not blocking)

- #80 — adopt `Cursor` module in `fcs_project_symbol_uses` and `fcs_find_symbol`
- #82 — replace `_summary` sentinel node with a top-level `memberCounts` map

## Files changed

| File | Change |
|---|---|
| `Cursor.fs` (new) | `encode` / `tryDecode` / `paginationFields` — reusable opaque base64 cursor module |
| `Types.fs` | `FcsProjectOutlineArgs` gains `summaryOnly`, `cursor`, `filter`, `nameContains` (all optional) |
| `FcsBridge.fs` | `ProjectOutline` rewritten: defaults, cursor decode/validate, deterministic sort, filter pipeline (regex with NonBacktracking + 250ms timeout + 1024-char cap), summaryOnly stripping with deep-clone fix, pagination envelope |
| `tests/OutlinePaginationTests.fs` (new) | 27 unit tests: cursor round-trip, malformed-cursor rejection, pagination fields, regex filter, default-args shape |
| `tests/OutlineE2ETests.fs` (new) | 6 integration tests: real `ProjectOutline` against a fixture fsproj — filter, regex DoS timing, length cap, page-1+page-2 reassembly |
| `tests/FcsBridgeTests.fs` | Updated existing outline test for new fields and `\"ok\"` status |

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 94/94 passing
- [x] DoS guard: pattern `(a+)+\$` completes in <1s
- [x] Cursor round-trip: page-1 + page-2 = expected total, no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)