### PR TITLE
feat(outline): replace _summary sentinel with memberCounts (closes #82)

### DIFF
--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -1273,22 +1273,19 @@ type internal FcsBridge() =
                             entryMatchesFilter name signature)
                         |> Array.truncate maxResultsPerFile
 
-                // summaryOnly: strip per-member signature detail, keep headers & counts.
+                // summaryOnly: strip per-member signature detail, keep headers; counts
+                // surface as a top-level memberCounts map per file (issue #82).
+                let containerKinds =
+                    [| "module"; "record"; "union"; "class"; "interface"; "enum"; "delegate"; "namespace" |]
+
                 let outlineEntries: JsonNode =
                     if summaryOnly then
-                        // Group by "kind" (module/record/union/class/interface) for a
-                        // compact header + member-count summary.
-                        let containerKinds =
-                            [| "module"; "record"; "union"; "class"; "interface"; "enum"; "delegate"; "namespace" |]
-
                         let topLevel =
                             filteredEntries
                             |> Array.filter (fun entry ->
                                 match entry["kind"] with
                                 | null -> false
                                 | k -> containerKinds |> Array.contains (k.GetValue<string>()))
-
-                        let memberCount = filteredEntries.Length - topLevel.Length
 
                         let summaryNodes =
                             topLevel
@@ -1306,31 +1303,41 @@ type internal FcsBridge() =
                                        | r -> r.DeepClone()) ]
                                 :> JsonNode)
 
-                        // Append a synthetic _members_count sentinel for LLM context.
-                        let withCount =
-                            Array.append
-                                summaryNodes
-                                [| jobj [ "kind", jstr "_summary"; "memberCount", jint memberCount ] :> JsonNode |]
-
-                        JsonArray(withCount) :> JsonNode
+                        JsonArray(summaryNodes) :> JsonNode
                     else
                         // Deep-clone each entry to release ownership from the source
                         // JsonArray returned by FileOutline — a JsonNode may only have
                         // one parent, so re-parenting without cloning throws.
                         JsonArray(filteredEntries |> Array.map (fun e -> e.DeepClone())) :> JsonNode
 
-                fileEntries.Add(
-                    jobj
-                        [ "file", jstr file.Path
-                          "kind", jstr (if file.IsSignature then "signature" else "implementation")
-                          "outlineStatus", outline["status"].DeepClone()
-                          "entries", outlineEntries
-                          "count",
-                          (match outline["count"] with
-                           | null -> jint 0
-                           | count -> count.DeepClone()) ]
-                    :> JsonNode
-                )
+                // memberCounts: kind → count. Computed from the post-filter pre-truncation
+                // list so the totals reflect what the agent could see at maxResultsPerFile=∞.
+                let memberCounts =
+                    let counts =
+                        filteredEntries
+                        |> Array.choose (fun entry ->
+                            match entry["kind"] with
+                            | null -> None
+                            | k -> Some(k.GetValue<string>()))
+                        |> Array.countBy id
+                        |> Array.sortBy fst
+                        |> Array.map (fun (kind, n) -> kind, jint n)
+                        |> Array.toList
+
+                    jobj counts :> JsonNode
+
+                let fileFields =
+                    [ "file", jstr file.Path
+                      "kind", jstr (if file.IsSignature then "signature" else "implementation")
+                      "outlineStatus", outline["status"].DeepClone()
+                      "entries", outlineEntries
+                      "memberCounts", memberCounts
+                      "count",
+                      (match outline["count"] with
+                       | null -> jint 0
+                       | count -> count.DeepClone()) ]
+
+                fileEntries.Add(jobj fileFields :> JsonNode)
 
             // ── Pagination envelope ─────────────────────────────────────────────
             let paginationFields =

--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -1233,6 +1233,10 @@ type internal FcsBridge() =
             let fileEntries = ResizeArray<JsonNode>()
 
             for file in pageFiles do
+                // Fetch the full per-file outline (maxResults = None) so memberCounts
+                // can report the true totals. Truncation is applied below to the
+                // entries array only — the cap is a presentation concern, not a
+                // counting concern.
                 let! outline =
                     this.FileOutline(
                         { path = file.Path
@@ -1241,7 +1245,7 @@ type internal FcsBridge() =
                           projectOptions = None
                           includePrivate = args.includePrivate
                           includeLocal = Some false
-                          maxResults = Some maxResultsPerFile }
+                          maxResults = None }
                     )
 
                 // Pull raw entries array (may be null if outline aborted).
@@ -1253,10 +1257,11 @@ type internal FcsBridge() =
                         | :? JsonArray as arr -> arr |> Seq.cast<JsonNode> |> Seq.toArray
                         | _ -> [||]
 
-                // Apply filter BEFORE truncation, then apply per-file cap.
-                let filteredEntries =
+                // Apply filter first, keep the unbounded post-filter set so memberCounts
+                // can report the true totals; then truncate for the entries array.
+                let postFilterEntries =
                     if filterRegex.IsNone && nameContains.IsNone then
-                        rawEntries |> Array.truncate maxResultsPerFile
+                        rawEntries
                     else
                         rawEntries
                         |> Array.filter (fun entry ->
@@ -1271,7 +1276,8 @@ type internal FcsBridge() =
                                 | s -> s.GetValue<string>()
 
                             entryMatchesFilter name signature)
-                        |> Array.truncate maxResultsPerFile
+
+                let filteredEntries = postFilterEntries |> Array.truncate maxResultsPerFile
 
                 // summaryOnly: strip per-member signature detail, keep headers; counts
                 // surface as a top-level memberCounts map per file (issue #82).
@@ -1310,11 +1316,12 @@ type internal FcsBridge() =
                         // one parent, so re-parenting without cloning throws.
                         JsonArray(filteredEntries |> Array.map (fun e -> e.DeepClone())) :> JsonNode
 
-                // memberCounts: kind → count. Computed from the post-filter pre-truncation
-                // list so the totals reflect what the agent could see at maxResultsPerFile=∞.
+                // memberCounts: kind → count over the unbounded post-filter set, so the
+                // map tells the agent how many of each kind the filter actually matched
+                // — independent of maxResultsPerFile, which only caps the entries array.
                 let memberCounts =
                     let counts =
-                        filteredEntries
+                        postFilterEntries
                         |> Array.choose (fun entry ->
                             match entry["kind"] with
                             | null -> None

--- a/tests/FsLangMcp.Tests/OutlineE2ETests.fs
+++ b/tests/FsLangMcp.Tests/OutlineE2ETests.fs
@@ -543,18 +543,16 @@ let ``ProjectOutline summaryOnly memberCounts reflects post-filter entries`` () 
             if Directory.Exists(root) then Directory.Delete(root, true)
     }
 
-// ─── K4. maxResultsPerFile interaction with memberCounts ─────────────────────
+// ─── K4. maxResultsPerFile caps entries[] but NOT memberCounts ───────────────
 //
-// CONTRACT NOTE: the FcsBridge code comment near memberCounts claims the map
-// is computed "post-filter pre-truncation". In practice the implementation
-// applies Array.truncate maxResultsPerFile *before* counting, so the counts
-// shrink alongside `entries`. This test pins that observed behaviour so the
-// PR ships a single, internally consistent contract — drift in either
-// direction (counts becoming truncation-immune, or growing past the cap)
-// will trip this test.
+// memberCounts is computed over the post-filter entries before truncation, so
+// the agent sees the *real* breakdown of what the file contains even when
+// entries[] is capped. Without this contract the map degrades into a noisy
+// duplicate of `entries.length`, defeating its purpose: telling the agent
+// "this file has 50 functions you didn't see in entries[]".
 
 [<Fact>]
-let ``ProjectOutline summaryOnly maxResultsPerFile=1 caps both entries and memberCounts to one entry`` () : System.Threading.Tasks.Task =
+let ``ProjectOutline summaryOnly maxResultsPerFile=1 caps entries but memberCounts reflects the full file`` () : System.Threading.Tasks.Task =
     task {
         let projectPath, root = createFixtureProject ()
         let bridge = FcsBridge()
@@ -574,42 +572,35 @@ let ``ProjectOutline summaryOnly maxResultsPerFile=1 caps both entries and membe
             Assert.True(files.Count >= 1, "Expected at least one file")
 
             for file in files |> Seq.cast<JsonNode> do
-                // entries (summary view) keeps only container kinds (module,
-                // record, etc.); with maxResultsPerFile=1, only the first
-                // surviving container survives — so length is <= 1.
+                // entries (summary view) is truncated per the cap.
                 let entries = file["entries"] :?> JsonArray
                 Assert.True(
                     entries.Count <= 1,
                     $"entries.Count must be <= 1 with maxResultsPerFile=1; got {entries.Count}"
                 )
 
-                // memberCounts must be non-null.
+                // memberCounts must be non-null and reflect the *full* per-file
+                // outline, ignoring maxResultsPerFile.
                 let counts = file["memberCounts"] :?> JsonObject
                 Assert.NotNull(counts)
 
-                // The fixture's first source-order entry per file is the
-                // module declaration, so module=1 must remain.
-                Assert.True(counts.ContainsKey("module"), "module kind must remain")
+                // Each fixture file has 1 module + 1 record + 1 let binding,
+                // and memberCounts must capture all three regardless of the
+                // entries cap.
+                Assert.True(counts.ContainsKey("module"), "module kind must be counted")
                 Assert.Equal(1, counts.["module"].GetValue<int>())
 
-                // Truncation is applied before counting in the current
-                // implementation: the totals across memberCounts must equal
-                // exactly 1, matching the truncated filteredEntries set.
-                let total =
-                    counts |> Seq.sumBy (fun kvp -> kvp.Value.GetValue<int>())
-
-                Assert.Equal(1, total)
-
-                // Therefore record / function_or_value must NOT appear.
-                Assert.False(
+                Assert.True(
                     counts.ContainsKey("record"),
-                    "record kind must not appear when maxResultsPerFile=1 truncates before counting"
+                    "record kind must be counted even when truncated out of entries[]"
                 )
+                Assert.Equal(1, counts.["record"].GetValue<int>())
 
-                Assert.False(
+                Assert.True(
                     counts.ContainsKey("function_or_value"),
-                    "function_or_value must not appear when maxResultsPerFile=1 truncates before counting"
+                    "function_or_value must be counted even when truncated out of entries[]"
                 )
+                Assert.Equal(1, counts.["function_or_value"].GetValue<int>())
         finally
             if Directory.Exists(root) then Directory.Delete(root, true)
     }

--- a/tests/FsLangMcp.Tests/OutlineE2ETests.fs
+++ b/tests/FsLangMcp.Tests/OutlineE2ETests.fs
@@ -338,3 +338,100 @@ let ``ProjectOutline cursor pagination: page-1 has nextCursor and page-2 returns
         finally
             if Directory.Exists(root) then Directory.Delete(root, true)
     }
+
+// ─── K. memberCounts replaces _summary sentinel (issue #82) ──────────────────
+//
+// In summaryOnly mode (the default), each file entry must:
+//   * carry a top-level `memberCounts` object: kind → count
+//   * NOT contain any synthetic `_summary` sentinel inside `entries`
+// The fixture files contain one module + one record + one let per file, so the
+// counts are deterministic.
+
+[<Fact>]
+let ``ProjectOutline summaryOnly emits memberCounts and drops _summary sentinel`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        summaryOnly = Some true }
+                )
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+            Assert.True(files.Count >= 1, "Expected at least one file in outline")
+
+            for file in files |> Seq.cast<JsonNode> do
+                // memberCounts must be a non-null object.
+                let counts = file["memberCounts"]
+                Assert.NotNull(counts)
+                let countsObj = counts :?> JsonObject
+
+                // No kind in memberCounts may be the synthetic "_summary".
+                Assert.False(
+                    countsObj.ContainsKey("_summary"),
+                    "memberCounts must not contain a '_summary' kind"
+                )
+
+                // Each value must be a positive integer.
+                for kvp in countsObj do
+                    let n = kvp.Value.GetValue<int>()
+                    let kind = kvp.Key
+                    Assert.True(n > 0, $"memberCounts {kind} must be > 0, got {n}")
+
+                // entries must NOT contain the legacy _summary sentinel.
+                let entries = file["entries"] :?> JsonArray
+
+                let hasSentinel =
+                    entries
+                    |> Seq.cast<JsonNode>
+                    |> Seq.exists (fun e ->
+                        match e["kind"] with
+                        | null -> false
+                        | k -> k.GetValue<string>() = "_summary")
+
+                Assert.False(hasSentinel, "_summary sentinel must not appear in entries")
+
+                // The fixture has at least a "module" — assert that's tracked.
+                let keys =
+                    countsObj
+                    |> Seq.map _.Key
+                    |> String.concat ","
+
+                Assert.True(
+                    countsObj.ContainsKey("module"),
+                    $"Expected 'module' kind in memberCounts; got keys: {keys}"
+                )
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+[<Fact>]
+let ``ProjectOutline summaryOnly=false still emits memberCounts`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        summaryOnly = Some false }
+                )
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+
+            for file in files |> Seq.cast<JsonNode> do
+                // memberCounts is always present so callers can rely on the shape.
+                Assert.NotNull(file["memberCounts"])
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }

--- a/tests/FsLangMcp.Tests/OutlineE2ETests.fs
+++ b/tests/FsLangMcp.Tests/OutlineE2ETests.fs
@@ -12,6 +12,9 @@ module FsLangMcp.Tests.OutlineE2ETests
 ///   I. Overlong filter (>1024 chars) → InvalidArgException
 ///   J. Cursor pagination round-trip: page-1 has nextCursor + truncated=true;
 ///      page-2 with that cursor returns the rest, no overlap
+///   K. memberCounts replaces _summary sentinel (issue #82): emitted in both
+///      summaryOnly modes, no synthetic kinds, exact values, filter-aware,
+///      and not shrunk by maxResultsPerFile truncation.
 
 open System
 open System.IO
@@ -432,6 +435,181 @@ let ``ProjectOutline summaryOnly=false still emits memberCounts`` () : System.Th
             for file in files |> Seq.cast<JsonNode> do
                 // memberCounts is always present so callers can rely on the shape.
                 Assert.NotNull(file["memberCounts"])
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+// ─── K2. Exact memberCounts values for the deterministic fixture ─────────────
+//
+// Each fixture file declares: 1 module + 1 record + 1 let-bound function. The
+// FCS outline also surfaces the record's field as kind="field" — so we assert
+// the three kinds the fixture is built around (module, record, function_or_value)
+// each have count=1. Field count is intentionally not asserted (it depends on
+// whether FCS chose to emit the field as a separate symbol use, which is an
+// FCS implementation detail outside this PR's contract).
+
+[<Fact>]
+let ``ProjectOutline summaryOnly memberCounts has module=1 record=1 function_or_value=1 per fixture file`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        summaryOnly = Some true }
+                )
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+            Assert.Equal(2, files.Count)
+
+            for file in files |> Seq.cast<JsonNode> do
+                let countsObj = file["memberCounts"] :?> JsonObject
+                let filePath = file["file"].GetValue<string>()
+
+                let getCount (kind: string) =
+                    match countsObj.[kind] with
+                    | null -> 0
+                    | n -> n.GetValue<int>()
+
+                Assert.Equal(1, getCount "module")
+                Assert.Equal(1, getCount "record")
+                let fnCount = getCount "function_or_value"
+                let msg = sprintf "Expected function_or_value=1 for %s, got %d" filePath fnCount
+                Assert.True((fnCount = 1), msg)
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+// ─── K3. Filter interaction — memberCounts uses post-filter entries ──────────
+//
+// With filter="Timer":
+//   File1: only the Timer record matches by name/signature; its module Alpha
+//          and getValue let do NOT match. So memberCounts must show record=1
+//          and must NOT show function_or_value (counting only post-filter).
+//   File2: nothing matches "Timer" — File2 may be absent from results, or
+//          present with empty memberCounts; we don't pin that here. We only
+//          assert the contract on File1.
+
+[<Fact>]
+let ``ProjectOutline summaryOnly memberCounts reflects post-filter entries`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        summaryOnly = Some true
+                        filter = Some "Timer" }
+                )
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+
+            // Find File1 (the one whose path ends with File1.fs).
+            let file1 =
+                files
+                |> Seq.cast<JsonNode>
+                |> Seq.tryFind (fun f -> f["file"].GetValue<string>().EndsWith("File1.fs"))
+
+            Assert.True(file1.IsSome, "File1.fs must be present after filter=Timer")
+            let file1 = file1.Value
+
+            let countsObj = file1["memberCounts"] :?> JsonObject
+
+            // Pre-filter, function_or_value=1 (getValue). Post-filter ("Timer"),
+            // getValue must NOT contribute to memberCounts.
+            let hasFnOrValue =
+                countsObj.ContainsKey("function_or_value")
+                && countsObj.["function_or_value"].GetValue<int>() > 0
+
+            Assert.False(
+                hasFnOrValue,
+                "memberCounts.function_or_value must not be > 0 when filter='Timer' excludes getValue"
+            )
+
+            // The Timer record must still be counted.
+            Assert.True(countsObj.ContainsKey("record"), "record kind must remain after filter=Timer")
+            Assert.Equal(1, countsObj.["record"].GetValue<int>())
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+// ─── K4. maxResultsPerFile interaction with memberCounts ─────────────────────
+//
+// CONTRACT NOTE: the FcsBridge code comment near memberCounts claims the map
+// is computed "post-filter pre-truncation". In practice the implementation
+// applies Array.truncate maxResultsPerFile *before* counting, so the counts
+// shrink alongside `entries`. This test pins that observed behaviour so the
+// PR ships a single, internally consistent contract — drift in either
+// direction (counts becoming truncation-immune, or growing past the cap)
+// will trip this test.
+
+[<Fact>]
+let ``ProjectOutline summaryOnly maxResultsPerFile=1 caps both entries and memberCounts to one entry`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! result =
+                bridge.ProjectOutline(
+                    { defaultArgs projectPath with
+                        maxFiles = Some 100
+                        summaryOnly = Some true
+                        maxResultsPerFile = Some 1 }
+                )
+
+            Assert.Equal("ok", result["status"].GetValue<string>())
+
+            let files = filesArray result
+            Assert.True(files.Count >= 1, "Expected at least one file")
+
+            for file in files |> Seq.cast<JsonNode> do
+                // entries (summary view) keeps only container kinds (module,
+                // record, etc.); with maxResultsPerFile=1, only the first
+                // surviving container survives — so length is <= 1.
+                let entries = file["entries"] :?> JsonArray
+                Assert.True(
+                    entries.Count <= 1,
+                    $"entries.Count must be <= 1 with maxResultsPerFile=1; got {entries.Count}"
+                )
+
+                // memberCounts must be non-null.
+                let counts = file["memberCounts"] :?> JsonObject
+                Assert.NotNull(counts)
+
+                // The fixture's first source-order entry per file is the
+                // module declaration, so module=1 must remain.
+                Assert.True(counts.ContainsKey("module"), "module kind must remain")
+                Assert.Equal(1, counts.["module"].GetValue<int>())
+
+                // Truncation is applied before counting in the current
+                // implementation: the totals across memberCounts must equal
+                // exactly 1, matching the truncated filteredEntries set.
+                let total =
+                    counts |> Seq.sumBy (fun kvp -> kvp.Value.GetValue<int>())
+
+                Assert.Equal(1, total)
+
+                // Therefore record / function_or_value must NOT appear.
+                Assert.False(
+                    counts.ContainsKey("record"),
+                    "record kind must not appear when maxResultsPerFile=1 truncates before counting"
+                )
+
+                Assert.False(
+                    counts.ContainsKey("function_or_value"),
+                    "function_or_value must not appear when maxResultsPerFile=1 truncates before counting"
+                )
         finally
             if Directory.Exists(root) then Directory.Delete(root, true)
     }


### PR DESCRIPTION
## Summary

- Drop the synthetic `{"kind":"_summary","memberCount":N}` node from `fcs_project_outline`'s `summaryOnly` mode.
- Surface a top-level `memberCounts: { kind: int, ... }` map per file entry instead, computed from the post-filter entry set and keyed by FCS symbol kind (`module`, `record`, `union`, `function_or_value`, …).
- `memberCounts` is emitted in both `summaryOnly` modes for shape consistency, so callers can rely on its presence.

## Why

The sentinel mixed real outline nodes with bookkeeping data and forced agents to filter it out before processing `entries`. A top-level map keeps `entries` clean and makes counts a first-class field.

## Test plan
- [x] New `OutlineE2ETests`: asserts `memberCounts` non-null, no `_summary` kind in the map, no sentinel node leaks into `entries`, summaryOnly=false also emits the map.
- [x] Full suite: 143 passed, 0 failed.