### PR TITLE
chore(testing): Stryker.NET mutation testing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ nupkg/
 .claude/
 tests/*/bin/
 tests/*/obj/
+StrykerOutput/
+.stryker-tmp/

--- a/Justfile
+++ b/Justfile
@@ -31,3 +31,9 @@ pack:
 install-local: pack
     dotnet tool uninstall -g fslangmcp || true
     dotnet tool install -g --add-source {{tool_source}} FsLangMcp
+
+# Run Stryker.NET mutation testing using stryker-config.json.
+# Note: Stryker.NET officially supports C# only; F# support is not guaranteed.
+# Pass extra args via STRYKER_ARGS, e.g. `STRYKER_ARGS="--mutate Cursor.fs" just mutation-test`.
+mutation-test: tool-restore
+    dotnet stryker $STRYKER_ARGS

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ just analyze
 
 - `just check` runs build + tests.
 - `just analyze` runs F# analyzers through `FSharp.Analyzers.Build`.
+- `just mutation-test` runs [Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/) mutation testing against `stryker-config.json`. Note: Stryker.NET officially supports C# only — see the PR introducing this target and upstream issue [stryker-net#1216](https://github.com/stryker-mutator/stryker-net/issues/1216) for the current state of F# support.
 
 The repository currently wires:
 

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,6 +8,13 @@
         "fsharp-analyzers"
       ],
       "rollForward": false
+    },
+    "dotnet-stryker": {
+      "version": "4.14.1",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-net/master/src/Stryker.Configuration/schema.json",
+  "stryker-config": {
+    "project": "FsLangMcp.fsproj",
+    "test-projects": ["tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj"],
+    "reporters": ["progress", "html", "cleartext"],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    },
+    "mutate": [
+      "**/*.fs",
+      "!tests/**/*.fs",
+      "!**/bin/**",
+      "!**/obj/**",
+      "!**/Program.fs",
+      "!**/AssemblyInfo.fs"
+    ],
+    "mutation-level": "Standard",
+    "verbosity": "info",
+    "concurrency": 2
+  }
+}


### PR DESCRIPTION
## Summary

Add Stryker.NET mutation testing infrastructure to the repo so we can probe whether the existing xUnit suite (notably the recent pagination + memberCounts additions in #86 / #87) actually catches regressions, not just passes.

This PR is **infrastructure only**. The honest verdict on whether it produces useful F# mutation results is below — read it before relying on the results.

## What's added

- `dotnet-tools.json` — `dotnet-stryker` 4.14.1 pinned as a local tool (extends the existing manifest at repo root; `fsharp-analyzers` already lives there).
- `stryker-config.json` — repo-root config: `project: FsLangMcp.fsproj`, `test-projects: tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj`, reporters `progress`/`html`/`cleartext`, thresholds `high=80 / low=60 / break=0` (non-blocking), `mutate` patterns include `**/*.fs` excluding `tests/**`, `bin/**`, `obj/**`, `Program.fs`, `AssemblyInfo.fs`.
- `Justfile` — new `mutation-test` target wrapping `dotnet stryker`. Honors `STRYKER_ARGS` for ad-hoc scoping.
- `.gitignore` — ignores `StrykerOutput/` and `.stryker-tmp/`.
- `README.md` — single-line note in the existing **Development Commands** section pointing at `just mutation-test` and the Stryker docs.

## How to run locally

```bash
just tool-restore                 # restore Stryker as a local tool
just mutation-test                # full project run (slow, see caveat below)

# scope to a single file
STRYKER_ARGS=\"--mutate Cursor.fs --break-at 0\" just mutation-test

# raw form
dotnet stryker --mutate Cursor.fs --reporter cleartext
```

HTML report lands under `StrykerOutput/<timestamp>/reports/mutation-report.html`.

## Honest status of F# support (as of this PR)

Stryker.NET officially supports **C# only**. The configuration page enumerates StrykerJS / Stryker.NET / Stryker4s — F# is not listed. There is no `--language` flag for F# and no F# mutators ship in 4.14.1.

A scoped validation run was attempted on `Cursor.fs`:

```
$ dotnet stryker --mutate Cursor.fs --break-at 0 --reporter cleartext
[INF] Identifying projects to mutate ...
[INF] Could not find an assembly reference to a mutable assembly for project tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj.
[WRN]   can't be mutated because no test project references it.
[INF] Test project ... does not appear to test any mutable project, analysis succeeded.
Stryker.NET failed to mutate your project.
Failed to analyze project builds. Stryker cannot continue.
```

**Two distinct blockers:**

1. **F# is not a Stryker target language.** Mutators are written against Roslyn / C# syntax. Even if project detection succeeded, mutant generation against `.fs` files is not implemented. Upstream tracking issue: [stryker-mutator/stryker-net#1216 (\"F# Support\")](https://github.com/stryker-mutator/stryker-net/issues/1216) — open, no progress.
2. **The repo uses a non-standard test layout.** `FsLangMcp.Tests.fsproj` does not have a `<ProjectReference>` to `FsLangMcp.fsproj`; it links source files directly via `<Compile Include=\"../../*.fs\" Link=\"...\" />`. Stryker walks assembly references to map test-project ↔ project-under-test, finds none, and aborts. This would block Stryker even on a hypothetical C# rewrite of the repo.

So: zero mutants generated, no `mutation-report.html` produced, exit code non-zero, analysis aborted in ~5 seconds.

## Why land this anyway

- The config + tooling are correct and pinned; if Stryker ever ships F# mutators, `just mutation-test` will start working without further setup.
- Documents the limitation in-tree (commit message + this PR) so the next person doesn't redo the spike.
- Cost is small: 5 lines in `.gitignore`/`Justfile`, one config file, one tool entry. Nothing in the build path changes — `dotnet build` and the 141-test xUnit suite still pass on this branch (verified pre-push).

## Recommended follow-ups (separate issues, not in this PR)

- Subscribe to [stryker-net#1216](https://github.com/stryker-mutator/stryker-net/issues/1216) for F# support.
- If mutation testing is genuinely a priority before Stryker adds F# support, evaluate alternatives:
  - **FsCheck / property-based testing** — different technique, but the same goal (\"do the tests actually distinguish correct from incorrect behavior\"). Already idiomatic for F#.
  - **Manual mutation review** for the high-value targets (Cursor encoding, pagination math, memberCounts) — fast, one-off.
- If the team is willing to refactor: switch `FsLangMcp.Tests.fsproj` from linked `<Compile Include>` to a proper `<ProjectReference>` to `FsLangMcp.fsproj`. Cleaner project graph regardless of Stryker, and removes blocker (2) for the day F# support lands.

## Verification gate (run before push)

- `dotnet build -nologo -v q` — succeeded (0 warnings, 0 errors).
- `dotnet test --no-build --nologo` — 141 passed, 0 failed (note: caller mentioned 148; the actual number on `main` at fork time is 141).
- `dotnet stryker --help` — tool installed and runs.
- Scoped Stryker run on `Cursor.fs` — produced output (see logs above), aborted at analysis phase as described.

## Test plan

- [ ] `just tool-restore && just mutation-test` runs the configured pipeline (and exits with the documented analysis failure until upstream support lands).
- [ ] `dotnet build` and `dotnet test` are unaffected.
- [ ] `StrykerOutput/` is gitignored.