### PR TITLE
ci(publish): NuGet Trusted Publishing via OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,18 @@
-# Publishes the NuGet package when a version tag (v*) is pushed.
-# Required: set NUGET_API_KEY in repo Settings → Secrets → Actions
+# Publishes the NuGet package on a v* tag push (or manual dispatch).
+#
+# Auth: NuGet Trusted Publishing via OIDC (NuGet/login@v1) — no long-lived
+# API keys. Configured at https://www.nuget.org/account/trusted-publishing
+# for repository Neftedollar/FsLangMCP, workflow publish.yml, environment
+# `release`. Pattern mirrors Neftedollar/FsMcp's publish flow.
+#
+# Version source of truth is the git tag: PackageVersion is overridden at
+# pack time from the tag name (v0.5.0 → 0.5.0), so patch releases can ship
+# by tag alone without touching FsLangMcp.fsproj.
 
 name: Publish NuGet
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"
@@ -11,27 +20,62 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    concurrency:
-      group: nuget-publish
-      cancel-in-progress: false
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: 10.0.x
 
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore FsLangMcp.slnx
 
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build FsLangMcp.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test FsLangMcp.slnx --configuration Release --no-build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Pack
-        run: dotnet pack --configuration Release --no-build
+        run: |
+          dotnet pack FsLangMcp.fsproj \
+            --configuration Release \
+            --no-build \
+            -p:PackageVersion=${{ steps.version.outputs.VERSION }} \
+            -o ./nupkgs
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget-packages
+          path: ./nupkgs/*.nupkg
+          if-no-files-found: error
+
+      - name: NuGet login (Trusted Publishing)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: Neftedollar
 
       - name: Push to NuGet
-        run: dotnet nuget push "nupkg/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          dotnet nuget push "./nupkgs/*.nupkg" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Create / update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: ./nupkgs/*.nupkg


### PR DESCRIPTION
## Summary

Replace the broken-since-day-one `NUGET_API_KEY`-based publish flow with **NuGet Trusted Publishing** via OIDC, mirroring Neftedollar/FsMcp's pattern. No long-lived secret is required.

## Why

The previous \`publish.yml\` used \`secrets.NUGET_API_KEY\`, which was never configured in repo Settings. Every tag push (most recently v0.5.0, before that v0.2.1) produced a red \`Publish NuGet\` run with the cryptic error \`Source parameter was not specified.\` — the empty secret value collapsed the \`--api-key\` arg and consumed \`--source\` as its value.

Confirmed: NuGet.org has never carried \`FsLangMcp\` (\`https://api.nuget.org/v3-flatcontainer/fslangmcp/index.json\` returns BlobNotFound). All releases to date have been local-only via \`dotnet pack\` + \`just install-local\`.

## Required out-of-band setup (one-time, by repo owner)

1. **nuget.org**: Account → Trusted Publishers → Add
   - repository: \`Neftedollar/FsLangMCP\`
   - workflow:   \`publish.yml\`
   - environment: \`release\`
   - package:    \`FsLangMcp\`
2. **GitHub repo settings**: Settings → Environments → New environment **\`release\`** (no protection rules required; optional reviewers fine).

## After merge — publish 0.5.0 to NuGet

Once (1) and (2) are in place, trigger the existing v0.5.0 tag against the new workflow:

\`\`\`
gh workflow run publish.yml --repo Neftedollar/FsLangMCP --ref v0.5.0
\`\`\`

The workflow will pack at version \`0.5.0\` (extracted from the tag), upload the \`.nupkg\` artifact, push to NuGet via OIDC, and update the existing GitHub Release with the \`.nupkg\` attached.

## Test plan
- [ ] Trusted Publisher configured on nuget.org
- [ ] \`release\` environment exists in GitHub repo settings
- [ ] Manual dispatch on \`v0.5.0\` succeeds end-to-end
- [ ] \`https://www.nuget.org/packages/FsLangMcp/0.5.0\` resolves
- [ ] GitHub Release v0.5.0 has \`FsLangMcp.0.5.0.nupkg\` attached