### PR TITLE
chore(build): TreatWarningsAsErrors + WarningLevel 5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <FSharpCompilerServiceVersion>43.12.203</FSharpCompilerServiceVersion>
     <FSharpCoreImplicitPackageVersion>10.1.203</FSharpCoreImplicitPackageVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>5</WarningLevel>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1608</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>

--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -611,11 +611,12 @@ type internal FcsBridge() =
                     checkResults.GetAllUsesOfAllSymbolsInFile()
                     |> Seq.filter (fun symbolUse -> includeAllUses || symbolUse.IsFromDefinition)
                     |> Seq.distinctBy (fun symbolUse ->
+                        let r = symbolUse.Range
                         symbolUse.Symbol.FullName,
-                        symbolUse.Range.StartLine,
-                        symbolUse.Range.StartColumn,
-                        symbolUse.Range.EndLine,
-                        symbolUse.Range.EndColumn)
+                        r.StartLine,
+                        r.StartColumn,
+                        r.EndLine,
+                        r.EndColumn)
                     |> Seq.truncate maxResults
                     |> Seq.map symbolUseToJson
                     |> Seq.toArray
@@ -666,12 +667,15 @@ type internal FcsBridge() =
                     |> Seq.filter _.IsFromDefinition
                     |> Seq.filter (fun symbolUse -> includeLocal || not (isNoisyLocalSymbol symbolUse))
                     |> Seq.distinctBy (fun symbolUse ->
+                        let r = symbolUse.Range
                         symbolUse.Symbol.FullName,
-                        symbolUse.Range.StartLine,
-                        symbolUse.Range.StartColumn,
-                        symbolUse.Range.EndLine,
-                        symbolUse.Range.EndColumn)
-                    |> Seq.sortBy (fun symbolUse -> symbolUse.Range.StartLine, symbolUse.Range.StartColumn)
+                        r.StartLine,
+                        r.StartColumn,
+                        r.EndLine,
+                        r.EndColumn)
+                    |> Seq.sortBy (fun symbolUse ->
+                        let r = symbolUse.Range
+                        r.StartLine, r.StartColumn)
                     |> Seq.truncate maxResults
                     |> Seq.map (fun symbolUse ->
                         jobj
@@ -763,7 +767,8 @@ type internal FcsBridge() =
                 allUses
                 |> Array.filter (fun symbolUse -> symbolMatches symbolUse.Symbol)
                 |> Array.sortBy (fun symbolUse ->
-                    symbolUse.FileName, symbolUse.Range.StartLine, symbolUse.Range.StartColumn)
+                    let r = symbolUse.Range
+                    symbolUse.FileName, r.StartLine, r.StartColumn)
 
             let totalMatched = sortedMatches.Length
 
@@ -839,15 +844,17 @@ type internal FcsBridge() =
                 |> Seq.filter (fun symbolUse -> symbolMatches query exact symbolUse.Symbol)
                 |> Seq.filter (fun symbolUse -> includeDeclaration || not symbolUse.IsFromDefinition)
                 |> Seq.sortBy (fun symbolUse ->
-                    symbolUse.Symbol.FullName, symbolUse.FileName, symbolUse.Range.StartLine, symbolUse.Range.StartColumn)
+                    let r = symbolUse.Range
+                    symbolUse.Symbol.FullName, symbolUse.FileName, r.StartLine, r.StartColumn)
                 |> Seq.toArray
 
             let useToJson (symbolUse: FSharpSymbolUse) =
-                let context = lineContextToJson contextLines symbolUse.FileName symbolUse.Range.StartLine
+                let r = symbolUse.Range
+                let context = lineContextToJson contextLines symbolUse.FileName r.StartLine
 
                 jobj
                     [ "file", jstr (normalizePath symbolUse.FileName)
-                      "range", rangeToJson symbolUse.Range
+                      "range", rangeToJson r
                       "isDefinition", jbool symbolUse.IsFromDefinition
                       "isReference", jbool symbolUse.IsFromUse
                       "lineText", context["lineText"].DeepClone()

--- a/Program.fs
+++ b/Program.fs
@@ -55,7 +55,8 @@ let private parseProjInfoOutput (path: string) (exitCode: int) (stdout: string) 
                 match arr.[0] with
                 | :? JsonObject as obj -> obj
                 | other ->
-                    jobj [ "warning", jstr (sprintf "unexpected element type: %s" (other.GetValueKind().ToString())) ]
+                    let kind = other.GetValueKind()
+                    jobj [ "warning", jstr (sprintf "unexpected element type: %s" (kind.ToString())) ]
             | :? JsonObject as obj -> obj
             | _ -> JsonObject()
 

--- a/Types.fs
+++ b/Types.fs
@@ -7,6 +7,7 @@ open System.Text.Json.Nodes
 
 // ─── Tool error DU ─────────────────────────────────────────────────────────────
 
+[<NoComparison>]
 type ToolError =
     | InvalidArgs of string
     | NotReady of string


### PR DESCRIPTION
## Problem

CI catches warnings via \`--warnaserror\` in \`ci.yml\`, but local \`dotnet build\` is completely silent. Developers only discover warnings at push time — a feedback loop that's hours too late.

This is Always-Rule 1 from the test-quality audit.

## Change

Add to \`Directory.Build.props\`:
- \`<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\`
- \`<WarningLevel>5</WarningLevel>\`

The existing \`NU1608\` carve-out is preserved.

## Latent warnings surfaced and fixed

Enabling WarningLevel 5 exposed 3 distinct warning types across 4 files:

| Location | Warning | Fix |
|---|---|---|
| \`Types.fs:10\` | FS1178 — \`ToolError\` not structurally comparable (contains \`exn\`) | Added \`[<NoComparison>]\` attribute |
| \`FcsBridge.fs:615-618\` | FS0052 — struct \`Range\` copied per-property in \`FileSymbols\` distinctBy | Bind \`let r = symbolUse.Range\` before tuple |
| \`FcsBridge.fs:670-674\` | FS0052 — same in \`FileOutline\` distinctBy | Same fix |
| \`FcsBridge.fs:674\` | FS0052 — same in \`FileOutline\` sortBy | Same fix |
| \`FcsBridge.fs:766\` | FS0052 — same in \`ProjectSymbolUses\` sortBy | Same fix |
| \`FcsBridge.fs:842\` | FS0052 — same in \`FindSymbol\` sortBy | Same fix |
| \`FcsBridge.fs:846\` | FS0052 — same in \`FindSymbol\` useToJson | Same fix |
| \`Program.fs:58\` | FS0052 — \`GetValueKind()\` struct accessed then \`.ToString()\` | Bind \`let kind = ...\` first |

## Verification

- \`dotnet build FsLangMcp.slnx --configuration Release\` → 0 warnings, 0 errors
- \`dotnet test FsLangMcp.slnx --no-build --configuration Release\` → 158/158 passed