### PR TITLE
chore: bump FsMcp 1.1.1 + adopt stdio GC defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bumped `FsMcp.Server` and `FsMcp.TaskApi` from 1.0.1 to 1.1.1.** No source changes required; build passes with 0 warnings at WarningLevel 5. New surface in 1.1.x (resources/subscribe, subscribeToolsChanged, HTTP RunSessionHandler) is not consumed by FsLangMCP — our tool list is static and we run on stdio only.
+- **Workstation GC + Concurrent GC defaults** baked into the published tool via `runtimeconfig.template.json`. Aligned with FsMcp 1.1.0's runtime-tuning guide for stdio servers. Operators can override with `DOTNET_gcServer=1` if they want Server GC. Reduces apparent RSS growth on dev laptops without affecting throughput at typical agent request rates.
+
 ## [0.5.0] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-06
+
 ### Changed
 
+- **Workstation GC + Concurrent GC defaults** baked into the published tool via `runtimeconfig.template.json`. The default Server GC commits memory aggressively and only releases under OS pressure — a poor fit for stdio MCP servers, which are bursty (load → idle → next FCS request) and rarely trigger pressure events on dev laptops. Workstation GC returns committed memory promptly while idle, dramatically reducing apparent RSS growth without measurable throughput impact at typical agent request rates. Operators can opt back into Server GC with `DOTNET_gcServer=1` (env always wins over `runtimeconfig`). Aligned with [FsMcp 1.1.0's runtime-tuning guide](https://github.com/Neftedollar/FsMcp/blob/main/docs/runtime-tuning.md).
 - **Bumped `FsMcp.Server` and `FsMcp.TaskApi` from 1.0.1 to 1.1.1.** No source changes required; build passes with 0 warnings at WarningLevel 5. New surface in 1.1.x (resources/subscribe, subscribeToolsChanged, HTTP RunSessionHandler) is not consumed by FsLangMCP — our tool list is static and we run on stdio only.
-- **Workstation GC + Concurrent GC defaults** baked into the published tool via `runtimeconfig.template.json`. Aligned with FsMcp 1.1.0's runtime-tuning guide for stdio servers. Operators can override with `DOTNET_gcServer=1` if they want Server GC. Reduces apparent RSS growth on dev laptops without affecting throughput at typical agent request rates.
 
 ## [0.5.0] - 2026-05-06
 
@@ -73,5 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Earlier releases (0.2.0, 0.3.0, 0.3.1, 0.4.0) shipped without tags;
   backfilling them would point at synthetic refs.
 -->
-[Unreleased]: https://github.com/Neftedollar/FsLangMCP/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/Neftedollar/FsLangMCP/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/Neftedollar/FsLangMCP/releases/tag/v0.5.1
 [0.5.0]: https://github.com/Neftedollar/FsLangMCP/releases/tag/v0.5.0

--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>FsLangMcp</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fslangmcp</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -35,8 +35,8 @@
       <IncludeAssets>build</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FsMcp.Server" Version="1.0.1" />
-    <PackageReference Include="FsMcp.TaskApi" Version="1.0.1" />
+    <PackageReference Include="FsMcp.Server" Version="1.1.1" />
+    <PackageReference Include="FsMcp.TaskApi" Version="1.1.1" />
     <PackageReference Include="G-Research.FSharp.Analyzers" Version="0.22.0" GeneratePathProperty="true">
       <IncludeAssets>analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ Environment fallbacks still work:
 - `FSAC_ARGS`
 - `FSA_PROJECT_PATH`
 
+### Garbage collector — tuned for stdio servers
+
+FsLangMCP ships with **Workstation GC + Concurrent GC** baked in via `runtimeconfig.template.json`. This is the recommended profile for stdio MCP servers per [FsMcp's runtime tuning guide](https://github.com/Neftedollar/FsMcp/blob/main/docs/runtime-tuning.md): an FCS workload is bursty (load → idle → next request), and Server GC's "don't release until OS pressure" produces alarming RSS growth on dev laptops that won't trigger pressure events.
+
+Operators can override at the env-var level if needed (env always wins over `runtimeconfig`):
+
+- `DOTNET_gcServer=1` — opt back into Server GC (higher throughput, holds memory longer)
+- `DOTNET_GCHeapHardLimitPercent=0xA` — cap heap at 10% of RAM (works with either GC mode)
+
 ## MCP Stdio Config (Installed Tool)
 
 ```json

--- a/runtimeconfig.template.json
+++ b/runtimeconfig.template.json
@@ -1,0 +1,6 @@
+{
+  "configProperties": {
+    "System.GC.Server": false,
+    "System.GC.Concurrent": true
+  }
+}

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -36,7 +36,7 @@
       <IncludeAssets>build</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FsMcp.Server" Version="1.0.1" />
+    <PackageReference Include="FsMcp.Server" Version="1.1.1" />
     <PackageReference Include="G-Research.FSharp.Analyzers" Version="0.22.0" GeneratePathProperty="true">
       <IncludeAssets>analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- `FsLangMcp.fsproj`: `FsMcp.Server` 1.0.1 → 1.1.1, `FsMcp.TaskApi` 1.0.1 → 1.1.1
- `tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj`: `FsMcp.Server` 1.0.1 → 1.1.1

## Code changes required

None. The two v1.1.1 source-breaking shifts did not surface in this codebase:

- **`DynamicServer.onToolsChanged` Obsolete migration**: not hit — FsLangMcp does not use `DynamicServer` at all.
- **`[<NoComparison>]`/`[<NoEquality>]` on FsMcp types**: not hit — no structural equality comparisons on `ToolDefinition`, `McpError`, or any other affected FsMcp types exist in the codebase.

Build result: **0 warnings, 0 errors** (with `TreatWarningsAsErrors=true` + `WarningLevel=5` in place).

## Tests

165 passed, 0 failed, 0 skipped (before and after — no regression).

## References

FsMcp v1.1.1 release notes: https://github.com/Neftedollar/FsMcp/releases/tag/v1.1.1