### PR TITLE
chore(deps): float patch versions on stable dependencies

### DIFF
--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -31,22 +31,22 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Service" Version="$(FSharpCompilerServiceVersion)" />
-    <PackageReference Include="FSharp.Analyzers.Build" Version="0.5.0">
+    <PackageReference Include="FSharp.Analyzers.Build" Version="0.5.*">
       <IncludeAssets>build</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FsMcp.Server" Version="1.1.1" />
-    <PackageReference Include="FsMcp.TaskApi" Version="1.1.1" />
-    <PackageReference Include="G-Research.FSharp.Analyzers" Version="0.22.0" GeneratePathProperty="true">
+    <PackageReference Include="FsMcp.Server" Version="1.1.*" />
+    <PackageReference Include="FsMcp.TaskApi" Version="1.1.*" />
+    <PackageReference Include="G-Research.FSharp.Analyzers" Version="0.22.*" GeneratePathProperty="true">
       <IncludeAssets>analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Ionide.Analyzers" Version="0.15.0" GeneratePathProperty="true">
+    <PackageReference Include="Ionide.Analyzers" Version="0.15.*" GeneratePathProperty="true">
       <IncludeAssets>analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Ionide.ProjInfo.FCS" Version="0.74.2" />
-    <PackageReference Include="StreamJsonRpc" Version="2.24.84" />
+    <PackageReference Include="Ionide.ProjInfo.FCS" Version="0.74.*" />
+    <PackageReference Include="StreamJsonRpc" Version="2.24.*" />
   </ItemGroup>
 
 </Project>

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -32,35 +32,35 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Service" Version="$(FSharpCompilerServiceVersion)" />
-    <PackageReference Include="FSharp.Analyzers.Build" Version="0.5.0">
+    <PackageReference Include="FSharp.Analyzers.Build" Version="0.5.*">
       <IncludeAssets>build</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FsMcp.Server" Version="1.1.1" />
-    <PackageReference Include="G-Research.FSharp.Analyzers" Version="0.22.0" GeneratePathProperty="true">
+    <PackageReference Include="FsMcp.Server" Version="1.1.*" />
+    <PackageReference Include="G-Research.FSharp.Analyzers" Version="0.22.*" GeneratePathProperty="true">
       <IncludeAssets>analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Ionide.Analyzers" Version="0.15.0" GeneratePathProperty="true">
+    <PackageReference Include="Ionide.Analyzers" Version="0.15.*" GeneratePathProperty="true">
       <IncludeAssets>analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Ionide.ProjInfo.FCS" Version="0.74.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="StreamJsonRpc" Version="2.24.84" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="Ionide.ProjInfo.FCS" Version="0.74.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.*" />
+    <PackageReference Include="StreamJsonRpc" Version="2.24.*" />
+    <PackageReference Include="xunit" Version="2.9.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- coverlet.msbuild instruments the test assembly (which directly compiles the source files
          via linked <Compile> items). IncludeTestAssembly=true is required because FsLangMcp.Tests.dll
          contains both the production and test code — there is no separate app dll. -->
-    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.*">
       <IncludeAssets>build; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FsCheck.Xunit" Version="3.3.3" />
+    <PackageReference Include="FsCheck.Xunit" Version="3.3.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Convert pinned patch versions to `Major.Minor.*` wildcards on packages where patch is mechanically a bugfix-only increment. Pulls upstream fixes automatically without per-PR bumps.

## What floated, what stayed pinned

**Floated** (build-tested, 165 tests pass):

| Package | Before | After |
|---|---|---|
| `FsMcp.Server`, `FsMcp.TaskApi` | 1.1.1 | `1.1.*` |
| `StreamJsonRpc` | 2.24.84 | `2.24.*` |
| `Microsoft.NET.Test.Sdk` | 17.12.0 | `17.12.*` |
| `xunit` | 2.9.3 | `2.9.*` |
| `xunit.runner.visualstudio` | 3.0.0 | `3.0.*` |
| `coverlet.msbuild` | 10.0.0 | `10.0.*` |
| `FsCheck.Xunit` | 3.3.3 | `3.3.*` |
| `FSharp.Analyzers.Build` | 0.5.0 | `0.5.*` |
| `G-Research.FSharp.Analyzers` | 0.22.0 | `0.22.*` |
| `Ionide.Analyzers` | 0.15.0 | `0.15.*` |
| `Ionide.ProjInfo.FCS` | 0.74.2 | `0.74.*` |

**Pinned** (semantic-affecting, must not drift):

| Package | Reason |
|---|---|
| `FSharp.Compiler.Service` 43.12.203 | parser/checker behavior changes affect our diagnostic output |
| `FSharpCoreImplicitPackageVersion` 10.1.203 | stdlib semantic shifts |
| `fsharp-analyzers` 0.36.0 (tools manifest) | explicit `rollForward: false` is the existing intentional choice |

## Immediate effect

First `dotnet restore` after this change resolved `xunit.runner.visualstudio` 3.0.0 → **3.0.2** automatically — exactly the bugfix-on-arrival behavior the strategy targets.

## Caveat (proposed follow-up)

Floating without a lock file means two `dotnet restore` runs at different times can resolve different patches. CI drift becomes invisible to source review. Recommended follow-up PR:
- Add `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>` to `Directory.Build.props`
- Commit `packages.lock.json` for both projects
- Add `--locked-mode` to CI restore step (fails build if lock and reality diverge — explicit signal)

This separation lets reviewers consider floating-version policy and lockfile-discipline policy independently.

## Test plan
- [x] `dotnet build FsLangMcp.slnx --configuration Release` — 0 warnings, 0 errors at WarningLevel 5
- [x] `dotnet test FsLangMcp.slnx --no-build --no-restore --configuration Release` — 165/165 pass
- [x] CI green (build-and-test + semgrep)