### PR TITLE
chore(tests): migrate to ProjectReference + InternalsVisibleTo (ADR-0001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,17 +30,15 @@ jobs:
         run: dotnet build FsLangMcp.slnx --no-restore --configuration Release --warnaserror
 
       - name: Test (with coverage)
-        # coverlet.msbuild with IncludeTestAssembly=true is required because this project
-        # compiles source files directly into the test assembly via linked <Compile> items
-        # (no separate app dll exists for the XPlat collector to instrument).
+        # coverlet.msbuild instruments FsLangMcp.dll via the ProjectReference graph (ADR-0001).
+        # IncludeTestAssembly is no longer needed — prod and test code are in separate assemblies.
         run: |
           dotnet test FsLangMcp.slnx --no-build --no-restore --configuration Release \
             /p:CollectCoverage=true \
             /p:CoverletOutputFormat=cobertura \
-            /p:CoverletOutput=./coverage/ \
-            /p:IncludeTestAssembly=true
+            /p:CoverletOutput=./coverage/
 
-      - name: Coverage gate (≥ 70% line)
+      - name: Coverage gate (≥ 55% line)
         run: |
           set -e
           # Find the cobertura xml produced by coverlet.msbuild
@@ -52,9 +50,13 @@ jobs:
           LINE_RATE=$(grep -oP 'line-rate="[0-9.]+"' "$COVERAGE_FILE" | head -1 | grep -oP '[0-9.]+')
           PERCENT=$(awk -v r="$LINE_RATE" 'BEGIN{printf "%.1f", r*100}')
           echo "Line coverage: ${PERCENT}%"
-          # Fail if < 70.0
-          awk -v r="$LINE_RATE" 'BEGIN{exit !(r >= 0.70)}' || {
-            echo "::error::Coverage ${PERCENT}% < 70% threshold"; exit 1
+          # Threshold recalibrated to 55% after ADR-0001 migration: the old 70% gate was measuring
+          # FsLangMcp.Tests.dll (which included production source via linked <Compile> items), so
+          # test-file lines were counted as covered. The new gate measures FsLangMcp.dll only.
+          # Raising the threshold is a separate follow-up once LspBridge.fs and Program.fs
+          # get integration test coverage.
+          awk -v r="$LINE_RATE" 'BEGIN{exit !(r >= 0.55)}' || {
+            echo "::error::Coverage ${PERCENT}% < 55% threshold"; exit 1
           }
 
       - name: Upload coverage artifact

--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -30,6 +30,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>FsLangMcp.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FSharp.Compiler.Service" Version="$(FSharpCompilerServiceVersion)" />
     <PackageReference Include="FSharp.Analyzers.Build" Version="0.5.*">
       <IncludeAssets>build</IncludeAssets>

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -7,16 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../../BoundedCache.fs" Link="BoundedCache.fs" />
-    <Compile Include="../../Types.fs" Link="Types.fs" />
-    <Compile Include="../../ProjectFiles.fs" Link="ProjectFiles.fs" />
-    <Compile Include="../../Cursor.fs" Link="Cursor.fs" />
-    <Compile Include="../../ProjectInspection.fs" Link="ProjectInspection.fs" />
-    <Compile Include="../../ProjectHealth.fs" Link="ProjectHealth.fs" />
-    <Compile Include="../../LspBridge.fs" Link="LspBridge.fs" />
-    <Compile Include="../../FcsBridge.fs" Link="FcsBridge.fs" />
-    <Compile Include="../../Tools.fs" Link="Tools.fs" />
-    <Compile Include="../../RuntimeStatus.fs" Link="RuntimeStatus.fs" />
+    <ProjectReference Include="../../FsLangMcp.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="VerifyModuleInitializer.fs" />
     <Compile Include="RuntimeStatusTests.fs" />
     <Compile Include="TypesToolsTests.fs" />
@@ -54,9 +48,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <!-- coverlet.msbuild instruments the test assembly (which directly compiles the source files
-         via linked <Compile> items). IncludeTestAssembly=true is required because FsLangMcp.Tests.dll
-         contains both the production and test code — there is no separate app dll. -->
+    <!-- coverlet.msbuild instruments FsLangMcp.dll (referenced via <ProjectReference>).
+         The default behaviour — exclude the test assembly from coverage — is correct now that
+         prod and test code live in separate assemblies (per ADR-0001). -->
     <PackageReference Include="coverlet.msbuild" Version="10.0.*">
       <IncludeAssets>build; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Implements the accepted decision from ADR-0001 (merged in #95). Mechanically migrates the test project from linked-`<Compile>` to a standard `<ProjectReference>` so that the project graph is visible to all .NET tooling (Stryker, profilers, coverage collectors, IDE features).

- **`FsLangMcp.fsproj`**: added `<AssemblyAttribute>` ItemGroup for `InternalsVisibleTo("FsLangMcp.Tests")` — the MSBuild approach worked on .NET 10; no fallback to `AssemblyInfo.fs` was needed.
- **`tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj`**: removed all 10 `<Compile Include="../../*.fs" Link="..."/>` items; added `<ProjectReference Include="../../FsLangMcp.fsproj" />`; updated the stale coverlet comment to reflect the new layout.
- **`.github/workflows/ci.yml`**: dropped `/p:IncludeTestAssembly=true`; updated surrounding comment; recalibrated the coverage gate from 70% to 55% (see below).

## Coverage gate recalibration

The old 70% threshold measured `FsLangMcp.Tests.dll`, which re-compiled all production source files via linked items — test-file lines were themselves counted as covered, inflating the metric. The new layout correctly measures `FsLangMcp.dll` only. The true baseline is **55%** (2538/4614 lines), driven down by `Program.fs` (entry point, 0/356 lines, not exercisable by unit tests) and `LspBridge.fs` (server I/O layer, 96/1006 lines). The gate is set at 55% to hold the real floor.

## Verification gate

- `dotnet build FsLangMcp.slnx --configuration Release` — 0 warnings, 0 errors (WarningLevel 5 / TreatWarningsAsErrors)
- `dotnet test` run twice — **159/159 passed**, no flakiness
- `dotnet test ... /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura` — coverage file produced, `FsLangMcp` module at 55% line / 42.1% branch / 52.2% method
- Internals accessible: `BoundedCache<_,_>`, `FcsBridge()`, `FsAutoCompleteBridge()`, `heapJson`, `WorkspaceNotification.*`, `WorkspaceSelection.*`, `filterProjectFiles`, `defaultFilterOptions` — all pass without accessibility errors

## Follow-up (out of scope for this PR)

Now that a separate `FsLangMcp.dll` exists, switching CI from `coverlet.msbuild` to `--collect:"XPlat Code Coverage"` is unblocked (the original blocker documented in #92 is gone). Recommend a follow-up PR to make that switch — it restores standard `dotnet test` tooling behaviour and unblocks coverage UI integrations.