### PR TITLE
chore: address inline review feedback (P1 codeAction + 4× P2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Guard — refuse non-tag refs
+        # workflow_dispatch defaults to running against the default branch, where
+        # GITHUB_REF_NAME = "main". The pack step below derives PackageVersion from
+        # ${GITHUB_REF_NAME#v}, which would emit "main" — not a valid NuGet version.
+        # Force callers to dispatch against an explicit v* tag (UI: "Use workflow from"
+        # → "Tags" → vX.Y.Z) or push a tag.
+        if: ${{ github.ref_type != 'tag' || !startsWith(github.ref_name, 'v') }}
+        run: |
+          echo "::error::This workflow must run against a v* tag. Got ref_type=${{ github.ref_type }} ref_name=${{ github.ref_name }}."
+          exit 1
+
       - uses: actions/checkout@v6
 
       - name: Setup .NET

--- a/Cursor.fs
+++ b/Cursor.fs
@@ -39,6 +39,12 @@ let tryDecode (cursor: string) : Result<CursorPayload, string> =
             use doc = JsonDocument.Parse(json)
             let root = doc.RootElement
 
+            // TryGetProperty throws InvalidOperationException unless the root is an
+            // object. Reject arrays / scalars with a structured Error rather than letting
+            // the exception escape and surface as an unexpected server error.
+            if root.ValueKind <> JsonValueKind.Object then
+                Error "cursor payload must be a JSON object"
+            else
             match root.TryGetProperty("offset") with
             | true, offsetEl ->
                 match offsetEl.ValueKind with

--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -305,7 +305,10 @@ type internal FcsBridge() =
     // Returns Some errorNode when validation fails; None when the path is acceptable.
     let validateSourcePath (toolName: string) (text: string option) (path: string) : JsonNode option =
         let fullPath = normalizePath path
-        let hasText = text |> Option.exists (fun t -> t <> "")
+        // The tool contract says supplying `text` carries unsaved buffer content; a new
+        // empty file is a valid editor state. Treat any Some _ — including Some "" — as
+        // a provided buffer; only None means "no buffer, must exist on disk".
+        let hasText = text |> Option.isSome
 
         if Directory.Exists(fullPath) then
             Some(
@@ -1206,7 +1209,17 @@ type internal FcsBridge() =
             // Callers that previously relied on the effectively-unlimited behaviour
             // must now opt in via explicit larger values or cursor pagination.
             let pageSize = args.maxFiles |> Option.defaultValue 50
+
+            // pageSize=0 would emit empty pages with truncated=true and a nextCursor
+            // whose offset never advances — a non-terminating loop for cursor-following
+            // clients. Reject up front.
+            if pageSize < 1 then
+                invalidArg (nameof args.maxFiles) $"maxFiles must be >= 1 (got {pageSize})"
+
             let maxResultsPerFile = args.maxResultsPerFile |> Option.defaultValue 30
+
+            if maxResultsPerFile < 0 then
+                invalidArg (nameof args.maxResultsPerFile) $"maxResultsPerFile must be >= 0 (got {maxResultsPerFile})"
             let summaryOnly = args.summaryOnly |> Option.defaultValue true
 
             // ── Build regex / substring matchers ───────────────────────────────

--- a/LspBridge.fs
+++ b/LspBridge.fs
@@ -835,11 +835,15 @@ type internal FsAutoCompleteBridge() =
             args.text,
             "textDocument/codeAction",
             fun uri ->
-                let pos = jobj [ "line", jint args.line; "character", jint args.character ]
+                // Each JsonNode has a single Parent reference; assigning the same instance
+                // as both `start` and `end` raises InvalidOperationException at the second
+                // attach. Build two distinct position nodes.
+                let posNode () =
+                    jobj [ "line", jint args.line; "character", jint args.character ] :> JsonNode
 
                 jobj
                     [ "textDocument", jobj [ "uri", jstr uri ]
-                      "range", jobj [ "start", pos :> JsonNode; "end", pos :> JsonNode ]
+                      "range", jobj [ "start", posNode (); "end", posNode () ]
                       "context", jobj [ "diagnostics", JsonArray() :> JsonNode ] ]
         )
 

--- a/RuntimeStatus.fs
+++ b/RuntimeStatus.fs
@@ -208,10 +208,17 @@ let buildSnapshot
 
     let processPart: JsonNode = jobj processFields
 
+    // p.HasExited can throw if the Process handle has been disposed by a concurrent
+    // SetProject / StopLspUnsafe between when fsacProcess was sampled and now. Treat
+    // any failure to read the handle as "no live child" rather than letting the
+    // diagnostics tool fail with an infra error during FSAC restarts.
+    let isLive (p: Process) =
+        try not p.HasExited with _ -> false
+
     let children: JsonNode =
         if includeChildren then
             match fsacProcess with
-            | Some p when not p.HasExited ->
+            | Some p when isLive p ->
                 let childJson = childProcessJson p
                 JsonArray(childJson)
             | _ -> JsonArray()

--- a/tests/FsLangMcp.Tests/CursorPropertyTests.fs
+++ b/tests/FsLangMcp.Tests/CursorPropertyTests.fs
@@ -4,10 +4,13 @@ module FsLangMcp.Tests.CursorPropertyTests
 /// and rejection of malformed inputs. These complement the example tests in
 /// OutlinePaginationTests.fs by exploring boundary cases via random generation.
 
+open System
+open System.Text
 open System.Text.Json.Nodes
 open FsCheck
 open FsCheck.Xunit
 open FsCheck.FSharp
+open global.Xunit
 open FsLangMcp.Cursor
 
 // ─── Round-trip ───────────────────────────────────────────────────────────────
@@ -85,3 +88,25 @@ let ``paginationFields: totalEstimate carries the caller-supplied unitName``
     let m = fields |> Map.ofList
     let totalEstimate = m.["totalEstimate"]
     totalEstimate.[unit].GetValue<int>() = total
+
+// ─── Non-object cursor payloads (regression test for review feedback) ────────
+//
+// `tryDecode` previously called `root.TryGetProperty("offset")` without ensuring
+// root.ValueKind = Object. For Base64 payloads decoding to valid non-object JSON
+// (arrays, scalars), TryGetProperty throws InvalidOperationException — bypassing
+// the Result-based error path. These tests pin the structured-error contract.
+
+let private encodeRaw (json: string) =
+    Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+
+[<Theory>]
+[<InlineData("[]")>]
+[<InlineData("[1,2,3]")>]
+[<InlineData("\"x\"")>]
+[<InlineData("42")>]
+[<InlineData("true")>]
+[<InlineData("null")>]
+let ``tryDecode rejects non-object JSON payloads with a structured Error`` (json: string) =
+    match tryDecode (encodeRaw json) with
+    | Error _ -> ()
+    | Ok _ -> Assert.Fail($"Expected Error for non-object payload {json}")

--- a/tests/FsLangMcp.Tests/OutlineE2ETests.fs
+++ b/tests/FsLangMcp.Tests/OutlineE2ETests.fs
@@ -604,3 +604,47 @@ let ``ProjectOutline summaryOnly maxResultsPerFile=1 caps entries but memberCoun
         finally
             if Directory.Exists(root) then Directory.Delete(root, true)
     }
+
+// ─── L. Reject pathological pagination args (regression test for review feedback)
+//
+// maxFiles=0 would return empty pages with truncated=true and a nextCursor whose
+// offset never advances — a non-terminating loop for cursor-following clients.
+// ProjectOutline must reject this up front rather than emit a malformed envelope.
+
+[<Fact>]
+let ``ProjectOutline rejects maxFiles=0 with InvalidArgException`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! ex =
+                Assert.ThrowsAsync<ArgumentException>(fun () ->
+                    bridge.ProjectOutline({ defaultArgs projectPath with maxFiles = Some 0 })
+                    :> System.Threading.Tasks.Task)
+
+            Assert.Contains("maxFiles", ex.Message)
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }
+
+[<Fact>]
+let ``ProjectOutline rejects negative maxResultsPerFile`` () : System.Threading.Tasks.Task =
+    task {
+        let projectPath, root = createFixtureProject ()
+        let bridge = FcsBridge()
+
+        try
+            let! ex =
+                Assert.ThrowsAsync<ArgumentException>(fun () ->
+                    bridge.ProjectOutline(
+                        { defaultArgs projectPath with
+                            maxFiles = Some 10
+                            maxResultsPerFile = Some -1 }
+                    )
+                    :> System.Threading.Tasks.Task)
+
+            Assert.Contains("maxResultsPerFile", ex.Message)
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+    }


### PR DESCRIPTION
## Summary

Re-scan of inline review comments across all PRs found 5 actionable bugs that were never landed. This PR addresses all of them in atomic per-fix commits.

## What's fixed

| Origin | Severity | Fix |
|---|---|---|
| **#43** | **P1** | `LspBridge.CodeAction` shared the same `pos` JsonNode as both `range.start` and `range.end` — InvalidOperationException at the second attach, every codeAction call broken. Build two distinct nodes. |
| #84a | P2 | `Cursor.tryDecode` called `TryGetProperty("offset")` without checking root.ValueKind = Object — non-object payloads (`[]`, `"x"`, `42`) escaped the Result-based error path as InvalidOperationException. Now structured Error. |
| #84b | P2 | `ProjectOutline` accepted `maxFiles=0` → emit empty pages with `truncated=true` + non-advancing `nextCursor` → cursor-following client loops forever. Now invalidArg. Companion: maxResultsPerFile < 0 also rejected. |
| #83 | P2 | `validateSourcePath` treated `text = Some ""` as "no buffer" — broke unsaved empty-file editor flow. Predicate flipped to `Option.isSome`. |
| #85 | P2 | `RuntimeStatus.HasExited` could throw on a Process handle disposed by concurrent SetProject / StopLspUnsafe — `fsharp_runtime_status` failed with infra error during FSAC restarts. Wrapped in a small `isLive` helper. |
| #89 | P2 | `publish.yml` workflow_dispatch derived `PackageVersion` from `${GITHUB_REF_NAME#v}` — running from the default branch produced `"main"`, opaque `dotnet pack` failure ~3 min later. Added an early guard that fails fast on non-`v*` refs. |

## Tests

- New `[<Theory>]` in `CursorPropertyTests.fs` — 6 cases covering `[]`, `[1,2,3]`, `"x"`, `42`, `true`, `null` — pin the structured-error contract for #84a.
- Two new `[<Fact>]` in `OutlineE2ETests.fs` — pin the maxFiles=0 and maxResultsPerFile<0 rejection contracts for #84b.
- Pre/post test count: 159 → 167. All pass at WarningLevel 5 / TreatWarningsAsErrors.

## Not addressed in this PR

- **PR #94** comment on lock-file enforcement — already deferred-by-design in PR #94's body. Separate decision worth its own PR.
- **PR #86** comment on memberCounts truncation — already fixed in the same PR (commit `7e5c44b`); the bot's review pointed at an intermediate snapshot. Stale, no action needed.
- **PR #88** comment on Stryker — PR was closed informational.

## Test plan
- [x] `dotnet build FsLangMcp.slnx --configuration Release` clean (0 warnings, 0 errors at level 5)
- [x] `dotnet test FsLangMcp.slnx ...` — 167/167 pass
- [ ] CI green