### PR TITLE
fix: set_project surfaces 'projectPath' in invalid_args message (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`fcs_nuget_members <packageId> <typeName>` — member-level companion to `fcs_nuget_types` (#125).** Enumerates the members of one type from a referenced NuGet assembly (methods, properties, fields, constructors, events, union cases) with formatted FCS signatures, accessibility, `[Obsolete]` flag, and XML-doc summary. Resolves the assembly through the same `GetReferencedAssemblies()` path as `fcs_nuget_types`; paginated (default 500, max 2000), returns an empty `matchedTypes` marker (not an error) on no match. Type matching is generic-arity-aware (a bare `FSharpOption` resolves the arity-suffixed compiled type), compiler-generated property accessors (`get_`/`set_`) are filtered so a property isn't duplicated by its accessor, and identical member rows are de-duplicated. +8 tests; the tool description passes the `docs/tool-description-schema.md` audit.
 
+### Fixed
+
+- **`set_project` now returns a clear `invalid_args` envelope naming `projectPath` when the argument is missing or supplied under the wrong key (#100).** Previously a wrong/missing key let `Path.GetFullPath(null)` throw `ArgumentNullException` whose message named the internal `path` parameter (`Value cannot be null. (Parameter 'path')`), misdirecting callers to the wrong field. The handler now routes through `ArgsValidation.requireNonBlank "projectPath"` before any path operation, matching the other six handlers standardised in #120. +2 tests.
+
 ### Security
 
 - **Patched the MessagePack serialization chain behind the StreamJsonRpc transport (DoS advisories).** `StreamJsonRpc` 2.24.\* → 2.25.\* (pulls patched `MessagePack` 2.5.302) and `Nerdbank.MessagePack` 1.1.62 → 1.2.30 (clears GHSA-92vj-hp7m-gwcj and GHSA-qjvr-435c-5fjh). Pinned `Microsoft.NET.StringTools` to 18.4.0: `Nerdbank.MessagePack` 1.2.30 drops the transitive StringTools 18.4.0 that had been masking MessagePack's stale 17.6.3 — which lacks `SpanBasedStringBuilder.Equals(string, StringComparison)` and silently breaks Ionide.ProjInfo's MSBuild project loading. `dotnet restore` now passes with NuGet audit enabled; 301/301 tests green.

--- a/LspBridge.fs
+++ b/LspBridge.fs
@@ -551,7 +551,14 @@ type internal FsAutoCompleteBridge() =
 
     member this.SetProject(args: SetProjectArgs) : Task<JsonNode> =
         task {
-            let inputPath = Path.GetFullPath(args.projectPath)
+            // Guard before Path.GetFullPath: a wrong/missing key deserializes projectPath to
+            // null, and Path.GetFullPath(null) throws ArgumentNullException naming the internal
+            // 'path' param — misleading callers who passed the wrong key. Surface 'projectPath'.
+            match ArgsValidation.requireNonBlank "projectPath" args.projectPath with
+            | Error envelope -> return envelope
+            | Ok projectPathArg ->
+
+            let inputPath = Path.GetFullPath(projectPathArg)
 
             if not (File.Exists(inputPath) || Directory.Exists(inputPath)) then
                 invalidArg (nameof args.projectPath) $"Path does not exist: %s{inputPath}"

--- a/tests/FsLangMcp.Tests/LspBridgeTests.fs
+++ b/tests/FsLangMcp.Tests/LspBridgeTests.fs
@@ -562,3 +562,39 @@ let ``mostRecentAnalyzedAt with fileGlob matching zero files is null`` () =
     let analyzedAtByUri = JsonObject()
     let result = diagnosticsResponseForWorkspace true 0 root mostRecent analyzedAtByUri
     Assert.Null(result["mostRecentAnalyzedAt"])
+
+// ─── set_project arg validation (#100) ───────────────────────────────────────
+
+[<Fact>]
+let ``SetProject with null projectPath returns invalid_args naming projectPath`` () : System.Threading.Tasks.Task =
+    task {
+        // A wrong/missing JSON key deserializes projectPath to null. The guard must
+        // return the standard invalid_args envelope naming the public field, not let
+        // Path.GetFullPath(null) throw ArgumentNullException naming the internal 'path'.
+        use bridge = new FsAutoCompleteBridge()
+
+        let! result =
+            bridge.SetProject(
+                { projectPath = null
+                  workspacePath = None
+                  restartLsp = Some false }
+            )
+
+        Assert.Equal("invalid_args", result["status"].GetValue<string>())
+        Assert.Contains("projectPath", result["message"].GetValue<string>())
+    }
+
+[<Fact>]
+let ``SetProject with blank projectPath returns invalid_args`` () : System.Threading.Tasks.Task =
+    task {
+        use bridge = new FsAutoCompleteBridge()
+
+        let! result =
+            bridge.SetProject(
+                { projectPath = "   "
+                  workspacePath = None
+                  restartLsp = Some false }
+            )
+
+        Assert.Equal("invalid_args", result["status"].GetValue<string>())
+    }


### PR DESCRIPTION
Fixes the misleading `set_project` error reported in #100 (2026-06-28).

## Problem

Calling `set_project` with the wrong argument key (`project` or `path` instead of the schema's `projectPath`) returned:

```
TransportError {"errorKind":"InvalidArgs","message":"Value cannot be null. (Parameter 'path')"}
```

The required field `projectPath` deserializes to `null`, and `Path.GetFullPath(null)` throws `ArgumentNullException` whose message names the framework's internal `path` parameter — pointing the caller (agent) at a field name that doesn't exist in the public schema.

## Fix

Guard `SetProject` with `ArgsValidation.requireNonBlank "projectPath"` before any path operation, returning the standard envelope:

```json
{ "status": "invalid_args", "message": "projectPath must be non-empty" }
```

This is the same helper the other six handlers were standardised onto in #120 — `set_project` was simply missed in that sweep. (The reporter's second ask — accepting `path`/`project` as aliases — is intentionally **not** done: all other tools use strict `projectPath`, and silently accepting aliases would mask schema drift.)

- `LspBridge.fs`: guard before `Path.GetFullPath`; +2 tests (null + blank `projectPath`), which run without a live FSAC process because the guard short-circuits first.
- `303/303` tests pass; `dotnet build -c Release` clean.

## Note on base branch

Stacked on `feat/125-fcs-nuget-members` (#126) so CI inherits that branch's security fix (a clean `dotnet restore` on `main` currently fails on the pre-existing MessagePack advisories). GitHub will auto-retarget this PR to `main` once #126 merges; merge #126 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
