### PR TITLE
feat(0.10.0): consolidated find + check tools (#128)

### DIFF
--- a/AGENT_INTEGRATION.md
+++ b/AGENT_INTEGRATION.md
@@ -24,10 +24,24 @@ Drop this into your project's `CLAUDE.md` (Claude Code), your `.cursorrules` (Cu
   the `fslangmcp` MCP server. Never use `rg` / `grep` (text search misses
   partial application, shadowing, aliased opens, and produces noise from
   comments / strings).
-- Call `mcp__fslangmcp__set_project` once per session, then use as needed:
-  `project_health`, `fcs_project_outline`, `workspace_symbol`,
-  `fcs_project_symbol_uses`, `textDocument_definition`,
-  `fcs_type_at_position`, `workspace_diagnostics`.
+- Call `mcp__fslangmcp__set_project` once per session. Then for the two most
+  common questions, reach for the consolidated entry points first:
+  - **"Where is X used / defined?"** → `mcp__fslangmcp__find` (one
+    multi-project symbol sweep that unions definitions, references,
+    record-field set sites, and member-usage sites across every member
+    project). It supersedes the lower-level `workspace_symbol`,
+    `fcs_find_symbol`, `fcs_project_symbol_uses`, `fcs_find_member_usages`,
+    `fcs_record_field_audit`, `textDocument_references`, and
+    `textDocument_definition`.
+  - **"Did my edit compile?"** → `mcp__fslangmcp__check` (one
+    `clean` / `errors` / `unknown` verdict from a FRESH in-process
+    type-check — no stale-`{}` false-clean, no `dotnet build` fallback). It
+    supersedes the lower-level `workspace_diagnostics`, `fsharp_compile`,
+    `fcs_check_file`, `fcs_parse_and_check_file`, and `fcs_validate_snippet`.
+  - Those twelve cluster tools stay available as lower-level primitives —
+    use them only when you need a specific knob `find` / `check` don't expose.
+  - Other entry points as needed: `project_health`, `fcs_project_outline`,
+    `fcs_type_at_position`.
 - `rg` remains correct for non-F# files (`.fsproj`, `paket.dependencies`,
   `Directory.Packages.props`, CI YAML) and textual idiom counts.
 
@@ -37,6 +51,8 @@ Apply the tool that matches the data shape, not the calendar:
 
 | Data shape                              | Tool                          |
 |-----------------------------------------|-------------------------------|
+| "Where is X used / defined?" (any symbol) | `find` — one multi-project sweep |
+| "Did my edit compile?" (yes/no verdict)   | `check` — fresh in-process verdict |
 | Semantic question on compiled F# source | fslangmcp                     |
 | Textual scan of .fsproj XML / YAML / md | rg                            |
 | NuGet third-party type enumeration      | `fcs_nuget_types` / `fcs_referenced_symbols` (shipped v0.7.0) |
@@ -54,10 +70,12 @@ Every subagent brief that touches F# code MUST include a "Tool discipline"
 section telling the subagent to:
 
 1. **Use `fslangmcp`** for all semantic F# queries. Spell out canonical
-   entry points: `mcp__fslangmcp__set_project` once, then
-   `workspace_diagnostics` after edits, `fcs_project_outline` for structure,
-   `workspace_symbol` / `textDocument_references` for navigation,
-   `fcs_type_at_position` for types.
+   entry points: `mcp__fslangmcp__set_project` once, then `check` for a
+   compile verdict after edits, `find` for "where is X used / defined?"
+   navigation, `fcs_project_outline` for structure, and `fcs_type_at_position`
+   for types. The single-project `workspace_symbol` / `textDocument_references`
+   / `workspace_diagnostics` primitives are lower-level fallbacks behind
+   `find` / `check`.
 2. **Use `rg` only for non-F# files** (`.fsproj`, `.md`, JSON, YAML, idiom
    counts).
 3. **Deliver a 5–10 bullet end-of-run UX report on `fslangmcp`** — what
@@ -88,10 +106,11 @@ A minimal F# subagent brief skeleton. Embed your task-specific content where ind
 ## Tool discipline — non-negotiable
 
 - For F# semantic queries (`.fs` / `.fsi`): use `fslangmcp` MCP. Call
-  `mcp__fslangmcp__set_project` ONCE with the repo root, then use
-  `workspace_diagnostics`, `fcs_project_outline`, `workspace_symbol`,
-  `textDocument_references`, `fcs_type_at_position`,
-  `textDocument_codeAction` as needed.
+  `mcp__fslangmcp__set_project` ONCE with the repo root, then use `find`
+  for "where is X used / defined?", `check` for "did my edit compile?",
+  and `fcs_project_outline` / `fcs_type_at_position` / `textDocument_codeAction`
+  as needed. The single-project `workspace_diagnostics`, `workspace_symbol`,
+  and `textDocument_references` are lower-level fallbacks behind `find` / `check`.
 - `rg` is OK for non-F# files (.fsproj, .md, .json, .yml).
 - For NuGet third-party type enumeration: `fcs_nuget_types` (exact
   assembly) and `fcs_referenced_symbols` (cross-assembly search), both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-28
+
+### Added
+
+- **`find <query>` — one multi-project symbol search that supersedes the seven single-project search tools (#128).** Sweeps every member `.fsproj` of the active solution and unions four site kinds in a single call: definitions, references, record-field set sites (`{ Field = expr }` and `{ x with Field = expr }`), and member-usage sites. This recovers cross-project usage sites that the single-project `fcs_find_symbol` / `fcs_record_field_audit` miss — on the consolidation validation fixture the single-project path surfaced **1** site where the whole-solution `find` sweep surfaced **11**. Bare `find(query)` suffices (`kind=auto`, `scope=auto` over the whole solution); optional `kind` (`auto`|`symbol`|`members`|`field`|`definition`|`position`) and `scope` (`auto`|`file`|`project`|`workspace`) narrow it. Falls back to the FSAC `workspace/symbol` index when the FCS sweep is empty, so `matched=false` is a real negative. Mechanics: `docs/tools-detailed.md#find`.
+- **`check` — one trustworthy type-check verdict that supersedes the five lower-level check tools (#128).** Returns a single `verdict` (`clean` | `errors` | `unknown`) collapsed from a FRESH in-process FCS type-check, so it never reports the stale-`{}` false-clean that `workspace_diagnostics` can serve right after an `Edit`/`Write` — the false-clean that historically drove agents to fall back to `dotnet build`. Bare `check()` covers the active project (`scope=auto`, `speed=trusted`); optional `scope` (`auto`|`file`|`project`|`workspace`|`snippet`), `path`, `snippet` (inline source), `speed` (`trusted` default | `fast` = cached FSAC snapshot), and `severity`. `unknown` means the check could not run (no project context), not a pass. Mechanics: `docs/tools-detailed.md#check`.
+
+### Changed
+
+- **The 12 legacy "cluster" tools are now routing-steered toward `find` / `check`.** The seven find-cluster descriptions (`fcs_find_symbol`, `fcs_record_field_audit`, `fcs_find_member_usages`, `workspace_symbol`, `fcs_project_symbol_uses`, `textDocument_references`, `textDocument_definition`) gained a trailing `Prefer find for cross-project work.` steer; the five check-cluster descriptions (`workspace_diagnostics`, `fsharp_compile`, `fcs_check_file`, `fcs_parse_and_check_file`, `fcs_validate_snippet`) gained `Prefer check for a yes/no verdict.` `fcs_record_field_audit` was trimmed before the steer (491 → 497 after; cut the `during widening refactors` clause and a `see` filler word) to stay within the 500-char `ToolDescriptionSchemaTests` / `audit-tool-descriptions.py` ceiling. README, `AGENT_INTEGRATION.md`, and `docs/tools-detailed.md` now lead with `find` / `check` and mark the twelve cluster tools as lower-level primitives. The cluster tools remain fully registered — actual removal is telemetry-gated and deferred to a future release.
+
 ## [0.9.3] - 2026-06-28
 
 ### Added

--- a/Dispatcher.fs
+++ b/Dispatcher.fs
@@ -30,6 +30,10 @@ type FindRequest =
     | ProjectSymbolUses of FcsProjectSymbolUsesArgs
     | References of ReferencesArgs
     | Definition of PositionArgs
+    /// Consolidated multi-project symbol search (issue #128, Stage 1). Routes to the
+    /// FCS union sweep; the FSAC workspace/symbol index is consulted only as the
+    /// matched=false tie-breaker, injected here so the substrate stays LSP-agnostic.
+    | Find of FindArgs
 
 /// Internal request representation for the "check" tool cluster.
 /// check-cluster spans both FCS (fcsBridge) and FSAC (lspBridge); the dispatcher
@@ -40,6 +44,10 @@ type CheckRequest =
     | CheckFile of FcsParseAndCheckArgs
     | ParseAndCheckFile of FcsParseAndCheckArgs
     | ValidateSnippet of FcsValidateSnippetArgs
+    /// Consolidated one-verdict check (issue #128, Stage 1). Routes to the fresh FCS
+    /// re-check substrate; the FSAC cached snapshot is projected in here as the
+    /// speed="fast"-only signal, keeping the FCS substrate LSP-agnostic.
+    | Check of CheckArgs
 
 [<RequireQualifiedAccess>]
 module FindDispatch =
@@ -55,6 +63,23 @@ module FindDispatch =
         | ProjectSymbolUses args -> fcsBridge.ProjectSymbolUses args
         | References args -> lspBridge.References args
         | Definition args -> lspBridge.Definition args
+        | Find args ->
+            // FSAC symbol-index probe: the ONLY consulted signal when the FCS sweep is
+            // empty. Defensive — any FSAC error (not ready, RPC failure) counts as 0,
+            // so matched=false still requires a genuinely empty index.
+            let fsacProbe (q: string) : Task<int> =
+                task {
+                    try
+                        let! response = lspBridge.WorkspaceSymbol { query = q }
+
+                        match response["result"] with
+                        | :? JsonArray as arr -> return arr.Count
+                        | _ -> return 0
+                    with _ ->
+                        return 0
+                }
+
+            fcsBridge.Find(args, fsacProbe = fsacProbe)
 
 [<RequireQualifiedAccess>]
 module CheckDispatch =
@@ -68,3 +93,23 @@ module CheckDispatch =
         | CheckFile args -> fcsBridge.CheckFile args
         | ParseAndCheckFile args -> fcsBridge.ParseAndCheckFile args
         | ValidateSnippet args -> fcsBridge.ValidateSnippet args
+        | Check args ->
+            // speed="fast" reads the cheap cached FSAC snapshot; project it from a
+            // workspace_diagnostics response so the FCS substrate stays LSP-agnostic.
+            // Defensive — any FSAC error (not ready, RPC failure) degrades to `empty`,
+            // which the fast path honestly reports as verdict="unknown".
+            let fsacSnapshot () : Task<CheckFsacSnapshot> =
+                task {
+                    try
+                        let diagArgs: DiagnosticsArgs =
+                            { path = args.path
+                              fileGlob = args.fileGlob
+                              severity = None }
+
+                        let! response = lspBridge.Diagnostics diagArgs
+                        return CheckFsacSnapshot.ofDiagnosticsResponse response
+                    with _ ->
+                        return CheckFsacSnapshot.empty
+                }
+
+            fcsBridge.Check(args, fsacSnapshot = fsacSnapshot)

--- a/Dispatcher.fs
+++ b/Dispatcher.fs
@@ -1,0 +1,70 @@
+module FsLangMcp.Dispatcher
+
+open System.Text.Json.Nodes
+open System.Threading.Tasks
+open FsLangMcp.Types
+open FsLangMcp.LspBridge
+open FsLangMcp.FcsBridge
+
+// ─── find/check dispatcher seam (issue #128, Stage 0) ───────────────────────────
+//
+// The 12 "cluster" tool handlers in Program.fs no longer call FcsBridge/LspBridge
+// directly — they route through this module. Each request DU case names one
+// cluster member; `run` maps it to the exact backend call the per-tool handler
+// made before. This is the internal seam Stage 1 mounts the consolidated
+// `find` / `check` tools on. Stage 0 is byte-identical: it only adds indirection.
+//
+// Wrapping concerns (concurrency gating via runLimited, projectPath fall-back to
+// the active set_project) stay in the Program.fs arg-adapters — they are not part
+// of member→backend routing and must remain exactly where they were to keep
+// externally-observable output unchanged.
+
+/// Internal request representation for the "find" tool cluster.
+/// find-cluster spans both FCS (fcsBridge) and FSAC (lspBridge); the dispatcher
+/// hides which backend each member resolves to.
+type FindRequest =
+    | FindSymbol of FcsFindSymbolArgs
+    | RecordFieldAudit of FcsRecordFieldAuditArgs
+    | FindMemberUsages of FcsFindMemberUsagesArgs
+    | WorkspaceSymbol of WorkspaceSymbolArgs
+    | ProjectSymbolUses of FcsProjectSymbolUsesArgs
+    | References of ReferencesArgs
+    | Definition of PositionArgs
+
+/// Internal request representation for the "check" tool cluster.
+/// check-cluster spans both FCS (fcsBridge) and FSAC (lspBridge); the dispatcher
+/// hides which backend each member resolves to.
+type CheckRequest =
+    | Diagnostics of DiagnosticsArgs
+    | Compile of FSharpCompileArgs
+    | CheckFile of FcsParseAndCheckArgs
+    | ParseAndCheckFile of FcsParseAndCheckArgs
+    | ValidateSnippet of FcsValidateSnippetArgs
+
+[<RequireQualifiedAccess>]
+module FindDispatch =
+
+    /// Route a find-cluster request to the same backend call its handler made
+    /// before the dispatcher seam was introduced.
+    let internal run (fcsBridge: FcsBridge) (lspBridge: FsAutoCompleteBridge) (request: FindRequest) : Task<JsonNode> =
+        match request with
+        | FindSymbol args -> fcsBridge.FindSymbol args
+        | RecordFieldAudit args -> fcsBridge.RecordFieldAudit args
+        | FindMemberUsages args -> fcsBridge.FindMemberUsages args
+        | WorkspaceSymbol args -> lspBridge.WorkspaceSymbol args
+        | ProjectSymbolUses args -> fcsBridge.ProjectSymbolUses args
+        | References args -> lspBridge.References args
+        | Definition args -> lspBridge.Definition args
+
+[<RequireQualifiedAccess>]
+module CheckDispatch =
+
+    /// Route a check-cluster request to the same backend call its handler made
+    /// before the dispatcher seam was introduced.
+    let internal run (fcsBridge: FcsBridge) (lspBridge: FsAutoCompleteBridge) (request: CheckRequest) : Task<JsonNode> =
+        match request with
+        | Diagnostics args -> lspBridge.Diagnostics args
+        | Compile args -> fcsBridge.CompileProject args
+        | CheckFile args -> fcsBridge.CheckFile args
+        | ParseAndCheckFile args -> fcsBridge.ParseAndCheckFile args
+        | ValidateSnippet args -> fcsBridge.ValidateSnippet args

--- a/FcsBridge.fs
+++ b/FcsBridge.fs
@@ -95,11 +95,134 @@ module private FieldFormClassifier =
                 | _ -> acc)
 
 
+// ─── check: cached FSAC diagnostics snapshot (issue #128, Stage 1) ──────────────
+//
+// The `check` tool's speed="fast" path reads the cheap cached FSAC publishDiagnostics
+// snapshot instead of re-type-checking in FCS. The FSAC dictionary lives in
+// FsAutoCompleteBridge, so — exactly like `find` injecting its fsacProbe — the
+// dispatcher projects a workspace_diagnostics response into this struct and hands it
+// to the FCS-only substrate, which therefore stays LSP-agnostic.
+//
+// Honesty contract: `MostRecentAnalyzedAt = None` (or `Ready = false`) is the stale
+// `{}` ambiguity from #100 — FSAC has not pushed analysis yet, so absence of cached
+// errors does NOT mean "clean". The fast path turns that into verdict="unknown"
+// rather than a false-clean.
+[<NoComparison; NoEquality>]
+type internal CheckFsacSnapshot =
+    { /// FSAC workspace reached the "ready" state (lspState = "ready").
+      Ready: bool
+      /// Number of files FSAC currently holds diagnostics for.
+      AnalyzedFileCount: int
+      /// Error-severity (LSP code 1) diagnostics across the snapshot.
+      ErrorCount: int
+      /// Warning-severity (LSP code 2) diagnostics across the snapshot.
+      WarningCount: int
+      /// Most recent analyzedAt / mostRecentAnalyzedAt timestamp, when present.
+      /// None is the un-analyzed (stale-`{}`) case — the fast path cannot confirm clean.
+      MostRecentAnalyzedAt: string option
+      /// Error-severity diagnostics, LSP-shaped, deep-cloned for surfacing.
+      ErrorDiagnostics: JsonNode }
+
+[<RequireQualifiedAccess>]
+module internal CheckFsacSnapshot =
+
+    let empty: CheckFsacSnapshot =
+        { Ready = false
+          AnalyzedFileCount = 0
+          ErrorCount = 0
+          WarningCount = 0
+          MostRecentAnalyzedAt = None
+          ErrorDiagnostics = JsonArray() }
+
+    /// Projects a workspace_diagnostics response (file or workspace shape) into a
+    /// CheckFsacSnapshot. Tolerant of missing fields — anything it cannot read
+    /// degrades toward `empty`, which the fast path reads as "unknown".
+    let ofDiagnosticsResponse (resp: JsonNode) : CheckFsacSnapshot =
+        try
+            let ready =
+                match resp["lspState"] with
+                | :? JsonValue as v ->
+                    match v.GetValue<string>() with
+                    | "ready" -> true
+                    | _ -> false
+                | _ -> false
+
+            let fileCount =
+                match resp["diagnosticsFileCount"] with
+                | :? JsonValue as v ->
+                    let mutable n = 0
+                    if v.TryGetValue(&n) then n else 0
+                | _ -> 0
+
+            let analyzedAt =
+                let read (key: string) =
+                    match resp[key] with
+                    | :? JsonValue as v ->
+                        match v.GetValue<string>() with
+                        | null -> None
+                        | s when String.IsNullOrWhiteSpace s -> None
+                        | s -> Some s
+                    | _ -> None
+
+                read "mostRecentAnalyzedAt" |> Option.orElseWith (fun () -> read "analyzedAt")
+
+            let mutable errorCount = 0
+            let mutable warningCount = 0
+            let errorDiags = JsonArray()
+
+            let severityOf (obj: JsonObject) =
+                match obj["severity"] with
+                | :? JsonValue as s ->
+                    let mutable code = 0
+                    if s.TryGetValue(&code) then code else 0
+                | _ -> 0
+
+            let consume (file: string option) (arr: JsonArray) =
+                for node in arr do
+                    match node with
+                    | :? JsonObject as obj ->
+                        match severityOf obj with
+                        | 1 ->
+                            errorCount <- errorCount + 1
+                            let clone = node.DeepClone()
+
+                            match file, clone with
+                            | Some f, (:? JsonObject as co) -> co["file"] <- jstr f
+                            | _ -> ()
+
+                            errorDiags.Add(clone)
+                        | 2 -> warningCount <- warningCount + 1
+                        | _ -> ()
+                    | _ -> ()
+
+            match resp["result"] with
+            | :? JsonArray as arr -> consume None arr
+            | :? JsonObject as obj ->
+                for kv in obj do
+                    match kv.Value with
+                    | :? JsonArray as arr -> consume (Some kv.Key) arr
+                    | _ -> ()
+            | _ -> ()
+
+            { Ready = ready
+              AnalyzedFileCount = fileCount
+              ErrorCount = errorCount
+              WarningCount = warningCount
+              MostRecentAnalyzedAt = analyzedAt
+              ErrorDiagnostics = errorDiags }
+        with _ ->
+            empty
+
 // ─── FcsBridge ─────────────────────────────────────────────────────────────────
 
 type internal FcsBridge() =
-    // Default FCS projectCacheSize is 3. We capture it so RuntimeStatus can report it.
-    let defaultProjectCacheSize = 3
+    // FCS default projectCacheSize is 3. The `find` multi-project union sweep
+    // (issue #128) re-checks EVERY member project of the active solution on each
+    // call; with a cache of 3 a >3-project solution thrashes FCS's project cache
+    // and re-pays the cold type-check cost every sweep. Raise it to a
+    // solution-scale bound so a whole solution stays warm between sweeps. We
+    // capture the value so RuntimeStatus can report it.
+    let defaultProjectCacheSize = 50
     // Single source of truth for checker flags used in both Create and CheckerConfig.
     let keepAssemblyContents = true
     let keepAllBackgroundResolutions = true
@@ -116,7 +239,10 @@ type internal FcsBridge() =
     // Bounded caches keyed by a string combining projectPath + projectOptions hash.
     // Keep the source label with the options so cache hits report the same
     // resolution path as the original miss.
-    let optionsCache = BoundedCache<string, FSharpProjectOptions * string>(10)
+    // Sized to keep a whole solution's resolved options warm during a `find` sweep
+    // (issue #128) — a 10-entry cache would evict early projects mid-sweep on a
+    // >10-project solution, forcing redundant Ionide.ProjInfo re-resolution.
+    let optionsCache = BoundedCache<string, FSharpProjectOptions * string>(50)
     let projectResultsCache = BoundedCache<string, FSharpCheckProjectResults>(3)
 
     let asTask (workflow: Async<'T>) : Task<'T> =
@@ -1975,6 +2101,1124 @@ type internal FcsBridge() =
                   JsonArray(scopedDiagnostics |> Array.map diagnosticToJson) :> JsonNode ]
 
             return jobj (baseFields @ paginationFields) :> JsonNode
+        }
+
+    // ── find: ParseAndCheckProject warm-up for one project (issue #128) ──────────
+    // Used by the set_project fire-and-forget pre-warm so the FIRST `find` sweep
+    // hits FCS's (now solution-scale) project cache instead of paying cold cost.
+    // Swallows all failures — pre-warming is a latency optimization, never a gate.
+    member this.PrewarmProject(fsproj: string) : Task<unit> =
+        task {
+            try
+                let! options, _ = this.ResolveFsprojOptions(normalizePath fsproj)
+                let! _ = checker.ParseAndCheckProject(options) |> asTask
+                return ()
+            with _ ->
+                return ()
+        }
+
+    // ── find: resolve the symbol name under a cursor (kind=position) ─────────────
+    // Returns Ok displayName (fed to the union sweep as an exact query) or Error
+    // envelope. Mirrors fcs_symbol_at_word's tolerant resolution: line + optional
+    // word/occurrence/character.
+    member private this.ResolveQueryAtPosition(args: FindArgs) : Task<Result<string, JsonNode>> =
+        task {
+            match args.path with
+            | None ->
+                return
+                    Error(
+                        jobj
+                            [ "status", jstr "invalid_args"
+                              "message", jstr "kind='position' requires 'path' (and 'line')." ]
+                        :> JsonNode
+                    )
+            | Some path when String.IsNullOrWhiteSpace path ->
+                return
+                    Error(
+                        jobj
+                            [ "status", jstr "invalid_args"
+                              "message", jstr "kind='position' requires 'path' (and 'line')." ]
+                        :> JsonNode
+                    )
+            | Some path ->
+                match args.line with
+                | None ->
+                    return
+                        Error(
+                            jobj
+                                [ "status", jstr "invalid_args"
+                                  "message", jstr "kind='position' requires 'line' (0-based)." ]
+                            :> JsonNode
+                        )
+                | Some line ->
+                    // FindArgs carries no unsaved-buffer field; resolve position against on-disk content.
+                    match validateSourcePath "find" None path with
+                    | Some err -> return Error err
+                    | None ->
+                        let! _, source, _, _, _, checkedResults =
+                            this.PrepareCheckContext(path, None, args.projectPath, None)
+
+                        match checkedResults with
+                        | None ->
+                            return
+                                Error(
+                                    jobj
+                                        [ "status", jstr "aborted"
+                                          "message", jstr "Type checking was aborted at the requested position." ]
+                                    :> JsonNode
+                                )
+                        | Some checkResults ->
+                            let lines = sourceLines source
+
+                            if line < 0 || line >= lines.Length then
+                                return
+                                    Error(
+                                        jobj
+                                            [ "status", jstr "invalid_args"
+                                              "message",
+                                              jstr $"line {line} is out of range (file has {lines.Length} lines)." ]
+                                        :> JsonNode
+                                    )
+                            else
+                                let lineText = lines[line]
+                                let candidates = wordSpans args.word lineText
+
+                                if candidates.Length = 0 then
+                                    return
+                                        Error(
+                                            jobj
+                                                [ "status", jstr "no_candidate"
+                                                  "message", jstr "No identifier found at the requested position." ]
+                                            :> JsonNode
+                                        )
+                                else
+                                    let occurrence = args.occurrence |> Option.defaultValue -1
+
+                                    let candidateIndex =
+                                        match args.character with
+                                        | Some ch ->
+                                            candidates
+                                            |> Array.tryFindIndex (fun (s, e, _) -> ch >= s && ch <= e)
+                                            |> Option.defaultValue 0
+                                        | None -> if occurrence < 0 then 0 else min occurrence (candidates.Length - 1)
+
+                                    let startColumn, endColumn, text = candidates[candidateIndex]
+                                    let fcsLine = line + 1
+                                    let columnsToTry = [| endColumn; startColumn + 1; startColumn |] |> Array.distinct
+
+                                    let symbolUse =
+                                        columnsToTry
+                                        |> Array.tryPick (fun column ->
+                                            checkResults.GetSymbolUseAtLocation(fcsLine, column, lineText, [ text ]))
+
+                                    match symbolUse with
+                                    | Some u -> return Ok u.Symbol.DisplayName
+                                    | None ->
+                                        return
+                                            Error(
+                                                jobj
+                                                    [ "status", jstr "no_symbol"
+                                                      "message",
+                                                      jstr
+                                                          $"Could not resolve a symbol at {Path.GetFileName path}:{line}." ]
+                                                :> JsonNode
+                                            )
+        }
+
+    // ── find: multi-project union sweep (issue #128, Stage 1) ───────────────────
+    // Productionized from spike/find-multiproject-sweep. Sweeps every member
+    // .fsproj of the active solution, unions each project's GetAllUsesOfAllSymbols()
+    // (de-duped by FULL source range), and auto-unions record-field and member
+    // usage sites the single-project fcs_find_symbol / fcs_record_field_audit miss.
+    //
+    // HEADLINE TRUST PROPERTY: matched=false is reported ONLY when BOTH the FCS
+    // multi-project sweep AND the FSAC workspace/symbol index (via the injected
+    // fsacProbe) are empty — never a confident "absent" from a single project,
+    // which would false-negative cross-project symbols (the RiskDebatorRole /
+    // TraderRole.Propose port-widening cases).
+    //
+    // FCS CROSS-COMPILATION INVARIANT (do NOT "fix" with ==): FSharpSymbol instances
+    // from DIFFERENT ParseAndCheckProject compilations are NOT reference-equal for
+    // the same logical symbol. We match the target by stable strings (DisplayName /
+    // FullName via symbolMatches; DeclaringEntity.DisplayName for fields/members)
+    // and de-dup by source LOCATION, never by symbol identity. FSharpSymbolUse is a
+    // struct, so we bind `let r = u.Range` before reading r.FileName (FS0052).
+    member this.Find(args: FindArgs, ?fsacProbe: string -> Task<int>) : Task<JsonNode> =
+        task {
+            match ArgsValidation.requireNonBlank "query" args.query with
+            | Error envelope -> return envelope
+            | Ok query0 ->
+
+            let kind = (args.kind |> Option.defaultValue "auto").Trim().ToLowerInvariant()
+            let scope = (args.scope |> Option.defaultValue "auto").Trim().ToLowerInvariant()
+            let exact = args.exact |> Option.defaultValue true
+            let contextLines = args.contextLines |> Option.defaultValue 1
+            let includeDeclaration = args.includeDeclaration |> Option.defaultValue true
+            let includeInfo = args.includeInfo |> Option.defaultValue false
+            let pageSize = args.maxResults |> Option.defaultValue 500
+
+            let pageOffset =
+                match args.cursor with
+                | None -> 0
+                | Some cursorStr ->
+                    match Cursor.tryDecode cursorStr with
+                    | Ok payload -> payload.offset
+                    | Error reason -> invalidArg (nameof args.cursor) $"Invalid cursor: %s{reason}"
+
+            // kind=position resolves the symbol under the cursor, then sweeps it as a symbol.
+            let! queryResult =
+                task {
+                    if kind = "position" then
+                        return! this.ResolveQueryAtPosition(args)
+                    else
+                        return Ok query0
+                }
+
+            match queryResult with
+            | Error envelope -> return envelope
+            | Ok query ->
+
+            let kindResolved = if kind = "position" then "symbol" else kind
+
+            // Resolve the sweep target: explicit projectPath (already falls back to the
+            // active set_project in Program.fs), else the nearest .fsproj to args.path.
+            let sweepTargetOpt =
+                args.projectPath
+                |> Option.filter (String.IsNullOrWhiteSpace >> not)
+                |> Option.map normalizePath
+                |> Option.orElseWith (fun () -> args.path |> Option.bind findNearestFsproj |> Option.map normalizePath)
+
+            match sweepTargetOpt with
+            | None ->
+                return
+                    jobj
+                        [ "status", jstr "invalid_args"
+                          "message",
+                          jstr
+                              "find needs a project context: pass projectPath (.fsproj/.sln/.slnx) or path, or call set_project first." ]
+                    :> JsonNode
+            | Some sweepTarget ->
+
+            let memberProjects = SolutionParsing.listProjects sweepTarget
+
+            // scope=file/project narrows to the single owning project; workspace/auto
+            // sweeps every member project of the solution.
+            let projectsToSweep =
+                match scope with
+                | "file"
+                | "project" ->
+                    let single =
+                        args.path
+                        |> Option.bind findNearestFsproj
+                        |> Option.orElseWith (fun () ->
+                            if sweepTarget.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase) then
+                                Some sweepTarget
+                            else
+                                None)
+
+                    match single with
+                    | Some p -> [| normalizePath p |]
+                    | None -> memberProjects
+                | _ -> memberProjects
+
+            if projectsToSweep.Length = 0 then
+                return
+                    jobj
+                        [ "status", jstr "invalid_args"
+                          "message",
+                          jstr $"find could not resolve any .fsproj to sweep from: {sweepTarget}" ]
+                    :> JsonNode
+            else
+
+            // ── Matching predicates (stable-string, cross-compilation-safe) ───────
+            let fullNameBoundaryMatch (fullName: string) =
+                not (isNull fullName)
+                && (String.Equals(fullName, query, StringComparison.Ordinal)
+                    || (fullName.EndsWith(query, StringComparison.Ordinal)
+                        && fullName.Length > query.Length
+                        && fullName[fullName.Length - query.Length - 1] = '.'))
+
+            let entityMatchesQuery (e: FSharpEntity) =
+                try
+                    String.Equals(e.DisplayName, query, StringComparison.Ordinal)
+                    || fullNameBoundaryMatch e.FullName
+                with _ ->
+                    false
+
+            let fieldRestrict = args.field
+            let memberRestrict = args.``member``
+
+            let isQueriedField (symbolUse: FSharpSymbolUse) =
+                match symbolUse.Symbol with
+                | :? FSharpField as field ->
+                    try
+                        let nameOk =
+                            match fieldRestrict with
+                            | Some fn -> String.Equals(field.Name, fn, StringComparison.Ordinal)
+                            | None -> true
+
+                        nameOk
+                        && (match field.DeclaringEntity with
+                            | Some e -> entityMatchesQuery e
+                            | None -> false)
+                    with _ ->
+                        false
+                | _ -> false
+
+            let isQueriedMember (symbolUse: FSharpSymbolUse) =
+                match symbolUse.Symbol with
+                | :? FSharpMemberOrFunctionOrValue as m when m.IsMember ->
+                    try
+                        let nameOk =
+                            match memberRestrict with
+                            | Some mn -> String.Equals(m.DisplayName, mn, StringComparison.Ordinal)
+                            | None -> true
+
+                        nameOk
+                        && (match m.DeclaringEntity with
+                            | Some e -> entityMatchesQuery e
+                            | None -> false)
+                    with _ ->
+                        false
+                | _ -> false
+
+            let wantName =
+                kindResolved = "auto" || kindResolved = "symbol" || kindResolved = "definition"
+
+            let wantDefsOnly = kindResolved = "definition"
+            let wantField = kindResolved = "auto" || kindResolved = "field"
+            let wantMember = kindResolved = "auto" || kindResolved = "members"
+
+            // De-dup accumulator keyed by stable source location.
+            // NOTE: we store only primitive coordinates, NOT the FCS `range` struct —
+            // `range` carries [<NoComparison>], and anonymous records auto-derive
+            // comparison, which would fail under warnings-as-errors. The range JSON is
+            // rebuilt from these fields in siteToJson.
+            let siteByKey =
+                System.Collections.Generic.Dictionary<
+                    string,
+                    {| File: string
+                       StartLine: int
+                       StartCol: int
+                       EndLine: int
+                       EndCol: int
+                       Kind: string
+                       Project: string
+                       FullName: string |}
+                 >()
+
+            let perProject = ResizeArray<JsonNode>()
+            let aggregatedDiagnostics = ResizeArray<FSharpDiagnostic>()
+            let sweepSw = System.Diagnostics.Stopwatch.StartNew()
+
+            let locationKey (r: range) =
+                $"{normalizePath r.FileName}:{r.StartLine}:{r.StartColumn}:{r.EndLine}:{r.EndColumn}"
+
+            // Per-project sweep. Sequential by design: parallel Ionide.ProjInfo option
+            // resolution races on MSBuild's *.nuget.g.props for sibling projects that
+            // share a P2P reference; FCS also serializes ParseAndCheckProject internally,
+            // so the set_project pre-warm + solution-scale cache (not intra-call
+            // parallelism) is what removes the cold cost. See the spike's -m:1 finding.
+            for fsproj in projectsToSweep do
+                let projSw = System.Diagnostics.Stopwatch.StartNew()
+                let projDisplay = Path.GetFileNameWithoutExtension fsproj
+
+                try
+                    let! options, _ = this.ResolveFsprojOptions(fsproj)
+                    let! results = checker.ParseAndCheckProject(options) |> asTask
+                    let allUses = results.GetAllUsesOfAllSymbols()
+                    aggregatedDiagnostics.AddRange(results.Diagnostics)
+
+                    // Per-file record-field form classifier (literal vs with-update).
+                    let parsingOptions, _ = checker.GetParsingOptionsFromProjectOptions(options)
+
+                    let formCache =
+                        System.Collections.Generic.Dictionary<
+                            string,
+                            System.Collections.Generic.Dictionary<FieldFormKey, bool> option
+                         >()
+
+                    let classifyForms (filePath: string) =
+                        match formCache.TryGetValue filePath with
+                        | true, cached -> cached
+                        | _ ->
+                            let parsed =
+                                try
+                                    if File.Exists filePath then
+                                        let st = SourceText.ofString (File.ReadAllText filePath)
+                                        let p = checker.ParseFile(filePath, st, parsingOptions) |> Async.RunSynchronously
+                                        Some(FieldFormClassifier.classify p.ParseTree)
+                                    else
+                                        None
+                                with _ ->
+                                    None
+
+                            formCache[filePath] <- parsed
+                            parsed
+
+                    let fieldKind (symbolUse: FSharpSymbolUse) =
+                        let r = symbolUse.Range
+
+                        match classifyForms (normalizePath r.FileName) with
+                        | Some d ->
+                            match d.TryGetValue((r.StartLine, r.StartColumn)) with
+                            | true, true -> "field-set-update"
+                            | true, false -> "field-set-literal"
+                            | _ -> "field-read"
+                        | None -> "field-read"
+
+                    let mutable nameCount = 0
+                    let mutable fieldCount = 0
+                    let mutable memberCount = 0
+
+                    let add (symbolUse: FSharpSymbolUse) (siteKind: string) (overwrite: bool) =
+                        let r = symbolUse.Range
+                        let key = locationKey r
+
+                        if overwrite || not (siteByKey.ContainsKey key) then
+                            siteByKey[key] <-
+                                {| File = normalizePath r.FileName
+                                   StartLine = r.StartLine
+                                   StartCol = r.StartColumn
+                                   EndLine = r.EndLine
+                                   EndCol = r.EndColumn
+                                   Kind = siteKind
+                                   Project = projDisplay
+                                   FullName =
+                                    (match symbolUse.Symbol.FullName with
+                                     | null -> null
+                                     | s -> s) |}
+
+                    // Field/member sites first so their richer kind wins over a generic
+                    // "reference" tag when a non-exact name-match overlaps the same range.
+                    if wantField then
+                        for u in allUses do
+                            if not u.IsFromDefinition && isQueriedField u then
+                                fieldCount <- fieldCount + 1
+                                add u (fieldKind u) true
+
+                    if wantMember then
+                        for u in allUses do
+                            if not u.IsFromDefinition && isQueriedMember u then
+                                memberCount <- memberCount + 1
+                                add u "member-usage" true
+
+                    if wantName then
+                        for u in allUses do
+                            if symbolMatches query exact u.Symbol then
+                                let passDefsOnly = (not wantDefsOnly) || u.IsFromDefinition
+                                let passDecl = wantDefsOnly || includeDeclaration || not u.IsFromDefinition
+
+                                if passDefsOnly && passDecl then
+                                    nameCount <- nameCount + 1
+                                    let k = if u.IsFromDefinition then "definition" else "reference"
+                                    add u k false
+
+                    projSw.Stop()
+
+                    perProject.Add(
+                        jobj
+                            [ "project", jstr projDisplay
+                              "fsproj", jstr (normalizePath fsproj)
+                              "totalProjectSymbolUses", jint allUses.Length
+                              "nameMatchUses", jint nameCount
+                              "fieldMatchUses", jint fieldCount
+                              "memberMatchUses", jint memberCount
+                              "elapsedMs", jint (int projSw.ElapsedMilliseconds) ]
+                        :> JsonNode
+                    )
+                with ex ->
+                    projSw.Stop()
+
+                    perProject.Add(
+                        jobj
+                            [ "project", jstr projDisplay
+                              "fsproj", jstr (normalizePath fsproj)
+                              "error", jstr ex.Message
+                              "elapsedMs", jint (int projSw.ElapsedMilliseconds) ]
+                        :> JsonNode
+                    )
+
+            sweepSw.Stop()
+
+            // scope=file post-filters to args.path's file (still type-checked in-project).
+            let allSites0 = siteByKey.Values |> Seq.toArray
+
+            let allSites =
+                if scope = "file" then
+                    match args.path with
+                    | Some p when not (String.IsNullOrWhiteSpace p) ->
+                        let pf = normalizePath p
+                        allSites0 |> Array.filter (fun s -> String.Equals(s.File, pf, StringComparison.Ordinal))
+                    | _ -> allSites0
+                else
+                    allSites0
+
+            let sortedSites =
+                allSites
+                |> Array.sortBy (fun s -> s.File, s.StartLine, s.StartCol, s.EndLine, s.EndCol, s.Kind)
+
+            let countKind (k: string) =
+                sortedSites |> Array.filter (fun s -> s.Kind = k) |> Array.length
+
+            let defCount = countKind "definition"
+            let refCount = countKind "reference"
+            let fLit = countKind "field-set-literal"
+            let fUpd = countKind "field-set-update"
+            let fRead = countKind "field-read"
+            let memCount = countKind "member-usage"
+            let totalSites = sortedSites.Length
+
+            // HEADLINE: matched is true if the FCS sweep found anything; only when it
+            // is empty do we consult the FSAC symbol index, and only when THAT is also
+            // empty do we report matched=false.
+            let fcsMatched = totalSites > 0
+
+            let! fsacHits =
+                task {
+                    if fcsMatched then
+                        return 0
+                    else
+                        match fsacProbe with
+                        | Some probe ->
+                            try
+                                return! probe query
+                            with _ ->
+                                return 0
+                        | None -> return 0
+                }
+
+            let matched = fcsMatched || fsacHits > 0
+
+            let via =
+                if fcsMatched then "fcs-multiproject-sweep"
+                elif fsacHits > 0 then "fsac-symbol-index"
+                else "none"
+
+            let pageSites =
+                sortedSites |> Array.skip (min pageOffset totalSites) |> Array.truncate pageSize
+
+            let siteToJson (s: {| File: string
+                                  StartLine: int
+                                  StartCol: int
+                                  EndLine: int
+                                  EndCol: int
+                                  Kind: string
+                                  Project: string
+                                  FullName: string |}) =
+                let ctx = lineContextToJson contextLines s.File s.StartLine
+
+                let rangeNode =
+                    jobj
+                        [ "file", jstr s.File
+                          "startLine", jint s.StartLine
+                          "startColumn", jint s.StartCol
+                          "endLine", jint s.EndLine
+                          "endColumn", jint s.EndCol ]
+                    :> JsonNode
+
+                jobj
+                    [ "file", jstr s.File
+                      "range", rangeNode
+                      "kind", jstr s.Kind
+                      "project", jstr s.Project
+                      "symbolFullName",
+                      (match s.FullName with
+                       | null -> null
+                       | v -> jstr v)
+                      "lineText", ctx["lineText"].DeepClone()
+                      "before", ctx["before"].DeepClone()
+                      "after", ctx["after"].DeepClone() ]
+                :> JsonNode
+
+            let pagePairs = pageSites |> Array.map (fun s -> s.Kind, siteToJson s)
+
+            let bucket (kinds: string list) =
+                pagePairs
+                |> Array.choose (fun (k, n) -> if List.contains k kinds then Some n else None)
+
+            let definitions = bucket [ "definition" ]
+            let references = bucket [ "reference" ]
+            let fieldSites = bucket [ "field-set-literal"; "field-set-update"; "field-read" ]
+            let memberSites = bucket [ "member-usage" ]
+            // A JsonNode can have only one parent: the grouped buckets above own the
+            // originals, so the flat legacy-superset `sites` array gets deep clones.
+            let flatSites = pagePairs |> Array.map (fun (_, n) -> n.DeepClone())
+
+            // Aggregated diagnostics across swept projects: Error always (so callers can
+            // detect broken projects even on zero hits), Warning/Info gated by includeInfo.
+            let diagNodes =
+                aggregatedDiagnostics.ToArray()
+                |> Array.filter (fun d ->
+                    d.Severity = FSharpDiagnosticSeverity.Error
+                    || (includeInfo
+                        && (d.Severity = FSharpDiagnosticSeverity.Warning
+                            || d.Severity = FSharpDiagnosticSeverity.Hidden
+                            || d.Severity = FSharpDiagnosticSeverity.Info)))
+                |> Array.truncate 200
+                |> Array.map diagnosticToJson
+
+            let scopeResolved =
+                if projectsToSweep.Length <= 1 then
+                    if scope = "file" then "file" else "project"
+                else
+                    "workspace"
+
+            let resolution =
+                jobj
+                    [ "matched", jbool matched
+                      "kindResolved", jstr kindResolved
+                      "scopeResolved", jstr scopeResolved
+                      "projectsSwept", jint projectsToSweep.Length
+                      "via", jstr via
+                      "fcsSiteCount", jint totalSites
+                      "fsacFallbackHits", jint fsacHits ]
+                :> JsonNode
+
+            let breakdown =
+                jobj
+                    [ "definitions", jint defCount
+                      "references", jint refCount
+                      "fieldSetLiteral", jint fLit
+                      "fieldSetUpdate", jint fUpd
+                      "fieldRead", jint fRead
+                      "memberUsages", jint memCount ]
+                :> JsonNode
+
+            let paginationFields =
+                Cursor.paginationFields "sites" totalSites pageOffset pageSize pageSites.Length
+
+            let baseFields =
+                [ "status", jstr "succeeded"
+                  "query", jstr query
+                  "kind", jstr kind
+                  "kindResolved", jstr kindResolved
+                  "scope", jstr scope
+                  "exact", jbool exact
+                  "resolution", resolution
+                  "projectsSwept", jint projectsToSweep.Length
+                  "totalSites", jint totalSites
+                  "matchedUseCount", jint totalSites
+                  "breakdown", breakdown
+                  "definitions", JsonArray(definitions) :> JsonNode
+                  "references", JsonArray(references) :> JsonNode
+                  "fieldSites", JsonArray(fieldSites) :> JsonNode
+                  "memberSites", JsonArray(memberSites) :> JsonNode
+                  "sites", JsonArray(flatSites) :> JsonNode
+                  "perProject", JsonArray(perProject.ToArray()) :> JsonNode
+                  "sweepElapsedMs", jint (int sweepSw.ElapsedMilliseconds)
+                  "projectDiagnostics", JsonArray(diagNodes) :> JsonNode ]
+
+            return jobj (baseFields @ paginationFields) :> JsonNode
+        }
+
+    // ── check: one fresh project type-check (issue #128, Stage 1) ────────────────
+    // Drops FCS's incremental builder + cached project results for THIS project so a
+    // source edit on disk is re-read — this is what makes the `check` verdict
+    // trustworthy (never a stale-`{}` false-clean). The resolved MSBuild options stay
+    // cached: they only change when the .fsproj itself changes, so re-resolving them
+    // every call would burn cost for no freshness gain. Ok carries the project's
+    // diagnostics; Error is a load failure ("timeout" or the exception message), which
+    // the caller turns into verdict="unknown" rather than a confident clean.
+    member private this.FreshProjectCheck
+        (fsproj: string, timeoutMs: int)
+        : Task<Result<FSharpDiagnostic array * string * string, string>> =
+        task {
+            try
+                let! options, optionsSource = this.ResolveFsprojOptions(normalizePath fsproj)
+                let cacheKey = makeResolvedProjectCacheKey options
+                projectResultsCache.TryRemove(cacheKey) |> ignore
+                checker.InvalidateConfiguration(options)
+                use cts = new CancellationTokenSource(timeoutMs)
+                let! results = Async.StartAsTask(checker.ParseAndCheckProject(options), cancellationToken = cts.Token)
+                return Ok(results.Diagnostics, options.ProjectFileName, optionsSource)
+            with
+            | :? OperationCanceledException
+            | :? TaskCanceledException -> return Error "timeout"
+            | ex -> return Error ex.Message
+        }
+
+    // ── check: one trustworthy verdict for the active context (issue #128) ───────
+    // Consolidates the 5 check-cluster tools (workspace_diagnostics, fsharp_compile,
+    // fcs_check_file, fcs_parse_and_check_file, fcs_validate_snippet) behind ONE field
+    // an agent can act on: `verdict` ∈ { "clean", "errors", "unknown" }.
+    //
+    // HEADLINE TRUST PROPERTY: the default speed="trusted" runs a FRESH in-process FCS
+    // re-check (FreshProjectCheck / cache-invalidated parse+check), so it can NEVER
+    // emit the stale-`{}` false-clean that made agents fall back to `dotnet build`
+    // (#100). "clean"/"errors" are terminal and ground-truth. "unknown" is returned
+    // ONLY when analysis genuinely could not run (aborted / timed out / a swept project
+    // failed to load) — honest, never a silently-escalated `dotnet build`.
+    //
+    // speed="fast" is the explicit opt-in to the cheap cached FSAC snapshot
+    // (old workspace_diagnostics behaviour). Even then, a cold cache (no analysis
+    // pushed yet) reports verdict="unknown" instead of a false-clean.
+    //
+    // RELOCATED-CHOICE GUARD: no output field tells the agent which tool to call next.
+    // The workspace_diagnostics → fresh-FCS-re-check escalation is hidden behind the
+    // verdict (surfaced only as the debug `escalated`/`via` fields).
+    //
+    // fsacSnapshot is injected (like find's fsacProbe) so this FCS substrate stays
+    // LSP-agnostic; it is consulted only on the speed="fast" path.
+    member this.Check(args: CheckArgs, ?fsacSnapshot: unit -> Task<CheckFsacSnapshot>) : Task<JsonNode> =
+        task {
+            let speed = (args.speed |> Option.defaultValue "trusted").Trim().ToLowerInvariant()
+            let mode = (args.mode |> Option.defaultValue "fs").Trim().ToLowerInvariant()
+            let severityFloor = (args.severity |> Option.defaultValue "error").Trim().ToLowerInvariant()
+            let scopeRaw = (args.scope |> Option.defaultValue "auto").Trim().ToLowerInvariant()
+            let timeoutMs = args.timeoutMs |> Option.defaultValue 60000
+
+            let invalid msg =
+                jobj [ "status", jstr "invalid_args"; "message", jstr msg ] :> JsonNode
+
+            let hasText (o: string option) =
+                o |> Option.exists (String.IsNullOrWhiteSpace >> not)
+
+            let severityNames =
+                [ "error"; "errors"; "warning"; "warnings"; "information"; "info"; "hint"; "hints"; "all" ]
+
+            if speed <> "trusted" && speed <> "fast" then
+                return invalid $"speed must be 'trusted' or 'fast' (got '{speed}')"
+            elif mode <> "fs" && mode <> "fsi" then
+                return invalid $"mode must be 'fs' or 'fsi' (got '{mode}')"
+            elif not (List.contains severityFloor severityNames) then
+                return invalid $"severity must be one of error|warning|information|hint|all (got '{severityFloor}')"
+            elif not (List.contains scopeRaw [ "auto"; "file"; "project"; "workspace"; "snippet" ]) then
+                return invalid $"scope must be one of auto|file|project|workspace|snippet (got '{scopeRaw}')"
+            else
+
+            // Severity floor → rank (Error = 1, highest). A diagnostic is surfaced in the
+            // `diagnostics` array when its rank ≤ the floor rank; errorCount/warningCount
+            // are always computed from the FULL set, independent of the floor.
+            let floorRank =
+                match severityFloor with
+                | "error"
+                | "errors" -> 1
+                | "warning"
+                | "warnings" -> 2
+                | "information"
+                | "info" -> 3
+                | "hint"
+                | "hints" -> 4
+                | _ -> 5 // "all"
+
+            let fcsRank (sev: FSharpDiagnosticSeverity) =
+                match sev with
+                | FSharpDiagnosticSeverity.Error -> 1
+                | FSharpDiagnosticSeverity.Warning -> 2
+                | FSharpDiagnosticSeverity.Info -> 3
+                | FSharpDiagnosticSeverity.Hidden -> 4
+
+            let passesFloor (sev: FSharpDiagnosticSeverity) = fcsRank sev <= floorRank
+
+            // Project / solution target for project + workspace scopes. (Program.fs has
+            // already defaulted projectPath to the active set_project.)
+            let sweepTargetOpt =
+                args.projectPath
+                |> Option.filter (String.IsNullOrWhiteSpace >> not)
+                |> Option.map normalizePath
+                |> Option.orElseWith (fun () -> args.path |> Option.bind findNearestFsproj |> Option.map normalizePath)
+
+            let resolvedScope =
+                match scopeRaw with
+                | "file" -> "file"
+                | "project" -> "project"
+                | "workspace" -> "workspace"
+                | "snippet" -> "snippet"
+                | _ -> // auto
+                    if hasText args.snippet then "snippet"
+                    elif hasText args.path then "file"
+                    else
+                        match sweepTargetOpt with
+                        | Some t -> if (SolutionParsing.listProjects t).Length > 1 then "workspace" else "project"
+                        | None -> "project"
+
+            // Single response builder — keeps the actionable header (verdict/analyzed/
+            // counts) identical across every scope and speed, then folds in the legacy
+            // superset + per-scope extras so migrating callers lose nothing.
+            let build
+                (verdict: string)
+                (analyzed: bool)
+                (via: string)
+                (escalated: string option)
+                (errorCount: int)
+                (warningCount: int)
+                (totalDiagnostics: int)
+                (diagNodes: JsonNode array)
+                (files: string array)
+                (reason: string option)
+                (extra: (string * JsonNode) list)
+                : JsonNode =
+                jobj (
+                    [ "status", jstr "succeeded"
+                      "verdict", jstr verdict
+                      "analyzed", jbool analyzed
+                      "scope", jstr resolvedScope
+                      "speed", jstr speed
+                      "errorCount", jint errorCount
+                      "warningCount", jint warningCount
+                      "diagnosticsFileCount", jint files.Length
+                      "files", JsonArray(files |> Array.map jstr) :> JsonNode
+                      "diagnostics", JsonArray(diagNodes) :> JsonNode
+                      // debug-only
+                      "escalated", (match escalated with Some e -> jstr e | None -> null)
+                      "via", jstr via
+                      // legacy superset
+                      "fresh", jbool (speed = "trusted")
+                      "groundTruth", jbool (analyzed && via = "fcs")
+                      "totalDiagnostics", jint totalDiagnostics
+                      "reason", (match reason with Some r -> jstr r | None -> null) ]
+                    @ extra
+                )
+                :> JsonNode
+
+            // FCS-diagnostics surfacing shared by every trusted (FCS) scope.
+            let surfaceFcs (diags: FSharpDiagnostic array) =
+                let surfaced = diags |> Array.filter (fun d -> passesFloor d.Severity)
+                let nodes = surfaced |> Array.map diagnosticToJson
+                let files = surfaced |> Array.map (fun d -> normalizePath d.FileName) |> Array.distinct
+                nodes, files
+
+            match resolvedScope with
+            // ── snippet: always FRESH (ignores speed); old ValidateSnippet logic ──
+            | "snippet" ->
+                match args.snippet with
+                | Some snippetText when not (String.IsNullOrWhiteSpace snippetText) ->
+                    let snippetProject =
+                        match args.projectPath with
+                        | Some p when not (String.IsNullOrWhiteSpace p) ->
+                            let np = normalizePath p
+
+                            if np.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase) then
+                                Some np
+                            else
+                                SolutionParsing.listProjects np |> Array.tryHead
+                        | _ -> args.path |> Option.bind findNearestFsproj |> Option.map normalizePath
+
+                    match snippetProject with
+                    | None ->
+                        return
+                            invalid
+                                "snippet check needs a project context: pass projectPath (.fsproj/.sln/.slnx) or path, or call set_project first."
+                    | Some fsproj ->
+                        let! options, optionsSource = this.ResolveFsprojOptions(fsproj)
+                        let ext = if mode = "fsi" then ".fsi" else ".fs"
+
+                        let snippetFile =
+                            Path.Combine(Path.GetTempPath(), $"fslangmcp_check_{Guid.NewGuid():N}{ext}")
+
+                        try
+                            File.WriteAllText(snippetFile, snippetText)
+
+                            let modifiedOptions =
+                                { options with
+                                    SourceFiles = Array.append options.SourceFiles [| snippetFile |] }
+
+                            let sourceText = SourceText.ofString snippetText
+
+                            let! parseResults, checkAnswer =
+                                checker.ParseAndCheckFileInProject(snippetFile, 0, sourceText, modifiedOptions)
+                                |> asTask
+
+                            let checkDiagnostics, succeeded =
+                                match checkAnswer with
+                                | FSharpCheckFileAnswer.Succeeded r -> r.Diagnostics, true
+                                | FSharpCheckFileAnswer.Aborted -> [||], false
+
+                            let allDiags = Array.append parseResults.Diagnostics checkDiagnostics
+                            let errorCount, warningCount = countDiagnosticsBySeverity allDiags
+
+                            let verdict, analyzed, reason =
+                                if not succeeded then
+                                    "unknown", false, Some "Type checking was aborted; snippet verdict is indeterminate."
+                                elif errorCount > 0 then
+                                    "errors", true, None
+                                else
+                                    "clean", true, None
+
+                            let nodes, _ = surfaceFcs allDiags
+
+                            return
+                                build
+                                    verdict
+                                    analyzed
+                                    "fcs"
+                                    None
+                                    errorCount
+                                    warningCount
+                                    allDiags.Length
+                                    nodes
+                                    [||] // synthetic temp file — no meaningful source path to surface
+                                    reason
+                                    [ "mode", jstr mode
+                                      "projectFileName", jstr options.ProjectFileName
+                                      "optionsSource", jstr optionsSource ]
+                        finally
+                            try
+                                if File.Exists snippetFile then
+                                    File.Delete snippetFile
+                            with _ ->
+                                ()
+                | _ -> return invalid "scope='snippet' requires non-empty 'snippet' text."
+
+            // ── file / project / workspace ───────────────────────────────────────
+            | _ when speed = "fast" ->
+                // Cheap cached FSAC snapshot. A cold cache (no analysis pushed yet) is
+                // the stale-`{}` ambiguity → verdict="unknown", NOT a false-clean.
+                let! snap =
+                    match fsacSnapshot with
+                    | Some thunk -> thunk ()
+                    | None -> Task.FromResult CheckFsacSnapshot.empty
+
+                let hasAnalysis = snap.Ready && snap.MostRecentAnalyzedAt.IsSome
+
+                let verdict, analyzed, reason =
+                    if not hasAnalysis then
+                        "unknown",
+                        false,
+                        Some
+                            "FSAC has not published diagnostics yet (cold cache); the default trusted check returns a ground-truth verdict."
+                    elif snap.ErrorCount > 0 then
+                        "errors", true, None
+                    else
+                        "clean", true, None
+
+                let nodes =
+                    match snap.ErrorDiagnostics with
+                    | :? JsonArray as arr -> arr |> Seq.map (fun n -> n.DeepClone()) |> Seq.toArray
+                    | _ -> [||]
+
+                let files =
+                    nodes
+                    |> Array.choose (fun n ->
+                        match n["file"] with
+                        | :? JsonValue as v -> Some(v.GetValue<string>())
+                        | _ -> None)
+                    |> Array.distinct
+
+                return
+                    build
+                        verdict
+                        analyzed
+                        "fsac"
+                        None
+                        snap.ErrorCount
+                        snap.WarningCount
+                        (snap.ErrorCount + snap.WarningCount)
+                        nodes
+                        files
+                        reason
+                        [ "lspState", jstr (if snap.Ready then "ready" else "warming")
+                          "mostRecentAnalyzedAt", (match snap.MostRecentAnalyzedAt with Some t -> jstr t | None -> null)
+                          "analyzedFileCount", jint snap.AnalyzedFileCount ]
+
+            | "file" ->
+                match args.path with
+                | Some path when not (String.IsNullOrWhiteSpace path) ->
+                    match validateSourcePath "check" None path with
+                    | Some err -> return err
+                    | None ->
+                        // Resolve options, invalidate THIS project, then re-check fresh so
+                        // on-disk edits (incl. cross-file) are reflected — mirrors fcs_check_file.
+                        let! _, _, _, projectOptions, _, _ =
+                            this.PrepareCheckContext(path, None, args.projectPath, None)
+
+                        let projectResultsKey = makeResolvedProjectCacheKey projectOptions
+                        projectResultsCache.TryRemove(projectResultsKey) |> ignore
+                        checker.InvalidateConfiguration(projectOptions)
+
+                        let! _, _, optionsSource, _, parseResults, checkedResults =
+                            this.PrepareCheckContext(path, None, args.projectPath, None)
+
+                        let checkDiagnostics =
+                            checkedResults
+                            |> Option.map (fun r -> r.Diagnostics)
+                            |> Option.defaultValue [||]
+
+                        let allDiags = Array.append parseResults.Diagnostics checkDiagnostics
+                        let succeeded = checkedResults.IsSome
+                        let errorCount, warningCount = countDiagnosticsBySeverity allDiags
+
+                        let verdict, analyzed, reason =
+                            if not succeeded then
+                                "unknown", false, Some "Type checking was aborted; file verdict is indeterminate."
+                            elif errorCount > 0 then
+                                "errors", true, None
+                            else
+                                "clean", true, None
+
+                        let nodes, files = surfaceFcs allDiags
+
+                        return
+                            build
+                                verdict
+                                analyzed
+                                "fcs"
+                                (Some "fcs-reanalyze")
+                                errorCount
+                                warningCount
+                                allDiags.Length
+                                nodes
+                                files
+                                reason
+                                [ "projectFileName", jstr projectOptions.ProjectFileName
+                                  "optionsSource", jstr optionsSource
+                                  "projectsSwept", jint 1 ]
+                | _ -> return invalid "scope='file' requires 'path'."
+
+            | "project" ->
+                match sweepTargetOpt with
+                | None ->
+                    return
+                        invalid
+                            "check needs a project context: pass projectPath (.fsproj/.sln/.slnx) or path, or call set_project first."
+                | Some target ->
+                    let fsproj =
+                        if target.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase) then
+                            Some target
+                        else
+                            args.path
+                            |> Option.bind findNearestFsproj
+                            |> Option.map normalizePath
+                            |> Option.orElseWith (fun () -> SolutionParsing.listProjects target |> Array.tryHead)
+
+                    match fsproj with
+                    | None -> return invalid $"check could not resolve a single .fsproj to check from: {target}"
+                    | Some proj ->
+                        let! result = this.FreshProjectCheck(proj, timeoutMs)
+
+                        match result with
+                        | Error "timeout" ->
+                            return
+                                build
+                                    "unknown"
+                                    false
+                                    "fcs"
+                                    (Some "fcs-reanalyze")
+                                    0
+                                    0
+                                    0
+                                    [||]
+                                    [||]
+                                    (Some $"FCS type-check timed out after {timeoutMs}ms.")
+                                    [ "projectsSwept", jint 1 ]
+                        | Error msg ->
+                            return
+                                build
+                                    "unknown"
+                                    false
+                                    "fcs"
+                                    (Some "fcs-reanalyze")
+                                    0
+                                    0
+                                    0
+                                    [||]
+                                    [||]
+                                    (Some $"Project could not be analyzed: {msg}")
+                                    [ "projectsSwept", jint 1 ]
+                        | Ok(diags, projFileName, optionsSource) ->
+                            let errorCount, warningCount = countDiagnosticsBySeverity diags
+                            let verdict = if errorCount > 0 then "errors" else "clean"
+                            let nodes, files = surfaceFcs diags
+
+                            return
+                                build
+                                    verdict
+                                    true
+                                    "fcs"
+                                    (Some "fcs-reanalyze")
+                                    errorCount
+                                    warningCount
+                                    diags.Length
+                                    nodes
+                                    files
+                                    None
+                                    [ "projectFileName", jstr projFileName
+                                      "optionsSource", jstr optionsSource
+                                      "projectsSwept", jint 1 ]
+
+            | "workspace" ->
+                match sweepTargetOpt with
+                | None ->
+                    return
+                        invalid
+                            "check needs a project context: pass projectPath (.fsproj/.sln/.slnx) or path, or call set_project first."
+                | Some target ->
+                    let projects0 = SolutionParsing.listProjects target
+
+                    let projects =
+                        if projects0.Length = 0 && target.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase) then
+                            [| target |]
+                        else
+                            projects0
+
+                    if projects.Length = 0 then
+                        return invalid $"check could not resolve any .fsproj to check from: {target}"
+                    else
+                        let allDiags = ResizeArray<FSharpDiagnostic>()
+                        let perProject = ResizeArray<JsonNode>()
+                        let mutable failCount = 0
+
+                        for proj in projects do
+                            let! result = this.FreshProjectCheck(proj, timeoutMs)
+
+                            match result with
+                            | Ok(diags, _, _) ->
+                                allDiags.AddRange diags
+                                let e, w = countDiagnosticsBySeverity diags
+
+                                perProject.Add(
+                                    jobj
+                                        [ "project", jstr (Path.GetFileNameWithoutExtension proj)
+                                          "fsproj", jstr (normalizePath proj)
+                                          "errorCount", jint e
+                                          "warningCount", jint w
+                                          "analyzed", jbool true ]
+                                    :> JsonNode
+                                )
+                            | Error msg ->
+                                failCount <- failCount + 1
+
+                                perProject.Add(
+                                    jobj
+                                        [ "project", jstr (Path.GetFileNameWithoutExtension proj)
+                                          "fsproj", jstr (normalizePath proj)
+                                          "error", jstr msg
+                                          "analyzed", jbool false ]
+                                    :> JsonNode
+                                )
+
+                        let diags = allDiags.ToArray()
+                        let errorCount, warningCount = countDiagnosticsBySeverity diags
+
+                        let verdict, analyzed, reason =
+                            if errorCount > 0 then
+                                "errors", true, None
+                            elif failCount > 0 then
+                                "unknown",
+                                false,
+                                Some $"{failCount} of {projects.Length} project(s) failed to analyze; cannot confirm clean."
+                            else
+                                "clean", true, None
+
+                        let nodes, files = surfaceFcs diags
+
+                        return
+                            build
+                                verdict
+                                analyzed
+                                "fcs"
+                                (Some "fcs-reanalyze")
+                                errorCount
+                                warningCount
+                                diags.Length
+                                nodes
+                                files
+                                reason
+                                [ "projectsSwept", jint projects.Length
+                                  "perProject", JsonArray(perProject.ToArray()) :> JsonNode ]
+
+            | _ -> return invalid $"unsupported scope '{resolvedScope}'"
         }
 
     member this.TypeAtPosition(args: FcsTypeAtPositionArgs) : Task<JsonNode> =

--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="FcsBridge.fs" />
     <Compile Include="Tools.fs" />
     <Compile Include="RuntimeStatus.fs" />
+    <Compile Include="Dispatcher.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/FsLangMcp.fsproj
+++ b/FsLangMcp.fsproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>FsLangMcp</PackageId>
-    <Version>0.9.3</Version>
+    <Version>0.10.0</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fslangmcp</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/Program.fs
+++ b/Program.fs
@@ -235,7 +235,7 @@ let main argv =
                 tool (
                     TypedTool.define<PositionArgs>
                         "textDocument_definition"
-                        "[FSAC] Raw LSP proxy to fsautocomplete textDocument/definition. Exact-position IDE primitive; requires set_project first. line/character are 0-based. Pass 'text' for unsaved content. Prefer fcs_find_symbol for agent flows — it returns grouped definitions+references and works without exact cursor position."
+                        "[FSAC] Raw LSP proxy to fsautocomplete textDocument/definition. Exact-position IDE primitive; requires set_project first. line/character are 0-based. Pass 'text' for unsaved content. Prefer fcs_find_symbol for agent flows — it returns grouped definitions+references and works without exact cursor position. Prefer find for cross-project work."
                         (fun args ->
                             toolResult (
                                 runLimited lspGate (fun () ->
@@ -246,7 +246,7 @@ let main argv =
                 tool (
                     TypedTool.define<ReferencesArgs>
                         "textDocument_references"
-                        "[FSAC] Raw LSP proxy to fsautocomplete textDocument/references. Exact-position IDE primitive; requires set_project first. For query-based agent workflows prefer project symbol-use tools. line/character are 0-based. Pass 'text' for unsaved content."
+                        "[FSAC] Raw LSP proxy to fsautocomplete textDocument/references. Exact-position IDE primitive; requires set_project first. For query-based agent workflows prefer project symbol-use tools. line/character are 0-based. Pass 'text' for unsaved content. Prefer find for cross-project work."
                         (fun args ->
                             toolResult (
                                 runLimited lspGate (fun () ->
@@ -257,7 +257,7 @@ let main argv =
                 tool (
                     TypedTool.define<WorkspaceSymbolArgs>
                         "workspace_symbol"
-                        "[FSAC] Raw LSP proxy to fsautocomplete workspace/symbol. Useful for quick lookup after set_project, but returns IDE-shaped results without source context. Prefer fcs_find_symbol for agent workflows — it returns grouped definitions+references with source-line context in one call."
+                        "[FSAC] Raw LSP proxy to fsautocomplete workspace/symbol. Useful for quick lookup after set_project, but returns IDE-shaped results without source context. Prefer fcs_find_symbol for agent workflows — it returns grouped definitions+references with source-line context in one call. Prefer find for cross-project work."
                         (fun args ->
                             toolResult (
                                 runLimited lspGate (fun () ->
@@ -268,7 +268,7 @@ let main argv =
                 tool (
                     TypedTool.define<DiagnosticsArgs>
                         "workspace_diagnostics"
-                        "[FSAC] Cached LSP publishDiagnostics payload, scoped to one file or the whole workspace. Requires `set_project` first. If diagnostics look stale right after Edit/Write, fall back to `fcs_check_file`. Optional: `path` (single file), `fileGlob` (e.g. `\"src/Adapters/*.fs\"` — narrows the workspace dict; ignored when `path` is set), `severity` (`error`|`warning`|`information`|`hint` — filters per file; empty entries dropped). Does not run build/tests."
+                        "[FSAC] Cached LSP publishDiagnostics payload, scoped to one file or the whole workspace. Requires `set_project` first. If diagnostics look stale right after Edit/Write, fall back to `fcs_check_file`. Optional: `path` (single file), `fileGlob` (e.g. `\"src/Adapters/*.fs\"` — narrows the workspace dict; ignored when `path` is set), `severity` (`error`|`warning`|`information`|`hint` — filters per file; empty entries dropped). Does not run build/tests. Prefer check for a yes/no verdict."
                         (fun args ->
                             toolResult (
                                 runLimited lspGate (fun () ->
@@ -279,7 +279,7 @@ let main argv =
                 tool (
                     TypedTool.define<FSharpCompileArgs>
                         "fsharp_compile"
-                        "[FCS in-process] Agent-friendly FCS project validation — loads project options via Ionide.ProjInfo, then runs `FSharpChecker.ParseAndCheckProject`. Prefer `dotnet build` for IL emission and cross-project ground truth; use this for cheap type-check-only validation. `projectPath` is optional after `set_project`. Does not run tests, does not emit assemblies."
+                        "[FCS in-process] Agent-friendly FCS project validation — loads project options via Ionide.ProjInfo, then runs `FSharpChecker.ParseAndCheckProject`. Prefer `dotnet build` for IL emission and cross-project ground truth; use this for cheap type-check-only validation. `projectPath` is optional after `set_project`. Does not run tests, does not emit assemblies. Prefer check for a yes/no verdict."
                         (fun args ->
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
@@ -287,6 +287,20 @@ let main argv =
                             toolResult (
                                 runLimited fcsGate (fun () ->
                                     Dispatcher.CheckDispatch.run fcsBridge bridge (Dispatcher.Compile args))))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<CheckArgs>
+                        "check"
+                        "[FSAC] One trustworthy verdict for the active F# context. Bare check() suffices: returns `verdict` (clean|errors|unknown) after a FRESH in-process type-check, so it never reports a stale-`{}` false-clean and you don't fall back to dotnet build. Optional: scope (auto|file|project|workspace|snippet), path, snippet (inline source), speed (trusted default | fast = cached FSAC snapshot), severity. Prefer over workspace_diagnostics / fcs_check_file when you just need a yes/no answer."
+                        (fun args ->
+                            let args =
+                                { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
+
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.CheckDispatch.run fcsBridge bridge (Dispatcher.Check args))))
                     |> unwrapResult
                 )
 
@@ -300,6 +314,30 @@ let main argv =
                                     task {
                                         let! result = bridge.SetProject args
                                         fcsBridge.ClearCaches()
+
+                                        // Fire-and-forget pre-warm (issue #128): kick a background
+                                        // ParseAndCheckProject over every member project so the FIRST
+                                        // `find` sweep hits FCS's (solution-scale) project cache warm
+                                        // instead of paying cold type-check cost. Acquire the fcsGate
+                                        // per project so concurrent real tool calls still interleave.
+                                        match bridge.CurrentProjectPath with
+                                        | Some activeProject ->
+                                            let warmTargets =
+                                                FsLangMcp.ProjectFiles.SolutionParsing.listProjects activeProject
+
+                                            if warmTargets.Length > 0 then
+                                                (task {
+                                                    for fsproj in warmTargets do
+                                                        do! fcsGate.WaitAsync()
+
+                                                        try
+                                                            do! fcsBridge.PrewarmProject fsproj
+                                                        finally
+                                                            fcsGate.Release() |> ignore
+                                                 }
+                                                 :> Task)
+                                                |> ignore
+                                        | None -> ()
 
                                         // Enrich readiness.projectOptions by probing the first loaded .fsproj.
                                         // Bridge cannot do this itself (no FCS handle); we own that wiring here.
@@ -375,7 +413,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsParseAndCheckArgs>
                         "fcs_parse_and_check_file"
-                        "[FCS in-process] Agent-friendly FCS parse+typecheck for one file. Prefer passing projectPath (.fsproj) for accurate project context; projectOptions can override. Falls back to script inference only when no project can be resolved. Pass 'text' for unsaved content."
+                        "[FCS in-process] Agent-friendly FCS parse+typecheck for one file. Prefer passing projectPath (.fsproj) for accurate project context; projectOptions can override. Falls back to script inference only when no project can be resolved. Pass 'text' for unsaved content. Prefer check for a yes/no verdict."
                         (fun args ->
                             toolResult (
                                 runLimited fcsGate (fun () ->
@@ -386,7 +424,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsParseAndCheckArgs>
                         "fcs_check_file"
-                        "[FCS in-process] Cache-invalidating parse+typecheck for one file. Use when `workspace_diagnostics` looks stale right after Edit/Write. Surgically drops project-options + project-results entries for THIS project and calls `InvalidateConfiguration` before re-running. Caveat: FCS may still serve from its internal AST cache for transitively-referenced files; fall back to `dotnet build` for ground truth. Mechanics: docs/tools-detailed.md#fcs_check_file."
+                        "[FCS in-process] Cache-invalidating parse+typecheck for one file. Use when `workspace_diagnostics` looks stale right after Edit/Write. Surgically drops project-options + project-results entries for THIS project and calls `InvalidateConfiguration` before re-running. Caveat: FCS may still serve from its internal AST cache for transitively-referenced files; fall back to `dotnet build` for ground truth. Mechanics: docs/tools-detailed.md#fcs_check_file. Prefer check for a yes/no verdict."
                         (fun args ->
                             toolResult (
                                 runLimited fcsGate (fun () ->
@@ -445,7 +483,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsValidateSnippetArgs>
                         "fcs_validate_snippet"
-                        "[FCS in-process] Compile arbitrary F# (`mode=\"fs\"|\"fsi\"`) against the active project's references without writing to the source tree. Use for 'does this signature type-check?' probes before scaffolding. Prefer `fcs_parse_and_check_file` when the file already exists on disk. Returns FCS diagnostics + errorCount/warningCount. `projectPath` falls back to active `set_project`. Caveats: docs/tools-detailed.md#fcs_validate_snippet."
+                        "[FCS in-process] Compile arbitrary F# (`mode=\"fs\"|\"fsi\"`) against the active project's references without writing to the source tree. Use for 'does this signature type-check?' probes before scaffolding. Prefer `fcs_parse_and_check_file` when the file already exists on disk. Returns FCS diagnostics + errorCount/warningCount. `projectPath` falls back to active `set_project`. Caveats: docs/tools-detailed.md#fcs_validate_snippet. Prefer check for a yes/no verdict."
                         (fun args ->
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
@@ -475,7 +513,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsProjectSymbolUsesArgs>
                         "fcs_project_symbol_uses"
-                        "[FCS in-process] Agent-friendly FCS project-wide symbol-use search by symbol name/full name. Results are cached by resolved project options. Prefer exact=true for narrow queries. Pass projectPath when possible and 'text' for unsaved content."
+                        "[FCS in-process] Agent-friendly FCS project-wide symbol-use search by symbol name/full name. Results are cached by resolved project options. Prefer exact=true for narrow queries. Pass projectPath when possible and 'text' for unsaved content. Prefer find for cross-project work."
                         (fun args ->
                             toolResult (
                                 runLimited fcsGate (fun () ->
@@ -486,7 +524,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsFindMemberUsagesArgs>
                         "fcs_find_member_usages"
-                        "[FCS in-process] Find every usage of a member on a specific type — resolves via FCS so dotted access (`x.Foo`), pipelines, and overload resolution are handled correctly (unlike a textual `rg`). Pass `typeName` (DisplayName or FullName) and `memberName` (exact, case-sensitive). `projectPath` is optional after `set_project`; pass `path`/`text` for unsaved buffers. typeName matching rules and caveats: docs/tools-detailed.md#fcs_find_member_usages."
+                        "[FCS in-process] Find every usage of a member on a specific type — resolves via FCS so dotted access (`x.Foo`), pipelines, and overload resolution are handled correctly (unlike a textual `rg`). Pass `typeName` (DisplayName or FullName) and `memberName` (exact, case-sensitive). `projectPath` is optional after `set_project`; pass `path`/`text` for unsaved buffers. typeName matching rules and caveats: docs/tools-detailed.md#fcs_find_member_usages. Prefer find for cross-project work."
                         (fun args ->
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
@@ -512,7 +550,7 @@ let main argv =
                 tool (
                     TypedTool.define<FcsRecordFieldAuditArgs>
                         "fcs_record_field_audit"
-                        "[FCS in-process] Find every construction site for a record field — literal `{ Field = expr }` AND update `{ x with Field = expr }`. Fills the gap left by fcs_find_symbol, which misses field-set uses during widening refactors. Pass typeName (DisplayName e.g. 'TraderRole' or segment-boundary FullName) and fieldName (exact, case-sensitive). Each site reports file, range, form, and 2 context lines. Paginated; default 200, max 1000. Caveats: see docs/tools-detailed.md#fcs_record_field_audit."
+                        "[FCS in-process] Find every construction site for a record field — literal `{ Field = expr }` AND update `{ x with Field = expr }`. Fills the gap left by fcs_find_symbol, which misses field-set uses. Pass typeName (DisplayName e.g. 'TraderRole' or segment-boundary FullName) and fieldName (exact, case-sensitive). Each site reports file, range, form, and 2 context lines. Paginated; default 200, max 1000. Caveats: docs/tools-detailed.md#fcs_record_field_audit. Prefer find for cross-project work."
                         (fun args ->
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
@@ -526,11 +564,25 @@ let main argv =
                 tool (
                     TypedTool.define<FcsFindSymbolArgs>
                         "fcs_find_symbol"
-                        "[FCS in-process] Project-wide symbol search with grouped definitions/references and source-line context in one call. Better than chaining workspace_symbol + fcs_project_symbol_uses + shell reads. Caveat: misses record-field-set sites — use fcs_record_field_audit for those. projectDiagnostics scoped to matched files; errors-only on zero hits. Info/Hint filtered by default (set includeInfo=true). Mechanics: see docs/tools-detailed.md#fcs_find_symbol."
+                        "[FCS in-process] Project-wide symbol search with grouped definitions/references and source-line context in one call. Better than chaining workspace_symbol + fcs_project_symbol_uses + shell reads. Caveat: misses record-field-set sites — use fcs_record_field_audit for those. projectDiagnostics scoped to matched files; errors-only on zero hits. Info/Hint filtered by default (set includeInfo=true). Mechanics: see docs/tools-detailed.md#fcs_find_symbol. Prefer find for cross-project work."
                         (fun args ->
                             toolResult (
                                 runLimited fcsGate (fun () ->
                                     Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.FindSymbol args))))
+                    |> unwrapResult
+                )
+
+                tool (
+                    TypedTool.define<FindArgs>
+                        "find"
+        "[FCS in-process] Multi-project symbol search. Sweeps every member .fsproj of the solution and unions definitions, references, record-field set sites, and member-usage sites — recovering cross-project sites single-project fcs_find_symbol / fcs_record_field_audit miss. Bare find(query) suffices; optional kind (auto|symbol|members|field|definition|position) + scope narrow it. Prefer over fcs_find_symbol for cross-project refactors. matched=false only when the FCS sweep and FSAC index are empty."
+                        (fun args ->
+                            let args =
+                                { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
+
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.Find args))))
                     |> unwrapResult
                 )
 

--- a/Program.fs
+++ b/Program.fs
@@ -236,7 +236,10 @@ let main argv =
                     TypedTool.define<PositionArgs>
                         "textDocument_definition"
                         "[FSAC] Raw LSP proxy to fsautocomplete textDocument/definition. Exact-position IDE primitive; requires set_project first. line/character are 0-based. Pass 'text' for unsaved content. Prefer fcs_find_symbol for agent flows — it returns grouped definitions+references and works without exact cursor position."
-                        (fun args -> toolResult (runLimited lspGate (fun () -> bridge.Definition args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited lspGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.Definition args))))
                     |> unwrapResult
                 )
 
@@ -244,7 +247,10 @@ let main argv =
                     TypedTool.define<ReferencesArgs>
                         "textDocument_references"
                         "[FSAC] Raw LSP proxy to fsautocomplete textDocument/references. Exact-position IDE primitive; requires set_project first. For query-based agent workflows prefer project symbol-use tools. line/character are 0-based. Pass 'text' for unsaved content."
-                        (fun args -> toolResult (runLimited lspGate (fun () -> bridge.References args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited lspGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.References args))))
                     |> unwrapResult
                 )
 
@@ -252,7 +258,10 @@ let main argv =
                     TypedTool.define<WorkspaceSymbolArgs>
                         "workspace_symbol"
                         "[FSAC] Raw LSP proxy to fsautocomplete workspace/symbol. Useful for quick lookup after set_project, but returns IDE-shaped results without source context. Prefer fcs_find_symbol for agent workflows — it returns grouped definitions+references with source-line context in one call."
-                        (fun args -> toolResult (runLimited lspGate (fun () -> bridge.WorkspaceSymbol args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited lspGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.WorkspaceSymbol args))))
                     |> unwrapResult
                 )
 
@@ -260,7 +269,10 @@ let main argv =
                     TypedTool.define<DiagnosticsArgs>
                         "workspace_diagnostics"
                         "[FSAC] Cached LSP publishDiagnostics payload, scoped to one file or the whole workspace. Requires `set_project` first. If diagnostics look stale right after Edit/Write, fall back to `fcs_check_file`. Optional: `path` (single file), `fileGlob` (e.g. `\"src/Adapters/*.fs\"` — narrows the workspace dict; ignored when `path` is set), `severity` (`error`|`warning`|`information`|`hint` — filters per file; empty entries dropped). Does not run build/tests."
-                        (fun args -> toolResult (runLimited lspGate (fun () -> bridge.Diagnostics args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited lspGate (fun () ->
+                                    Dispatcher.CheckDispatch.run fcsBridge bridge (Dispatcher.Diagnostics args))))
                     |> unwrapResult
                 )
 
@@ -272,7 +284,9 @@ let main argv =
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
 
-                            toolResult (runLimited fcsGate (fun () -> fcsBridge.CompileProject args)))
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.CheckDispatch.run fcsBridge bridge (Dispatcher.Compile args))))
                     |> unwrapResult
                 )
 
@@ -362,7 +376,10 @@ let main argv =
                     TypedTool.define<FcsParseAndCheckArgs>
                         "fcs_parse_and_check_file"
                         "[FCS in-process] Agent-friendly FCS parse+typecheck for one file. Prefer passing projectPath (.fsproj) for accurate project context; projectOptions can override. Falls back to script inference only when no project can be resolved. Pass 'text' for unsaved content."
-                        (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.ParseAndCheckFile args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.CheckDispatch.run fcsBridge bridge (Dispatcher.ParseAndCheckFile args))))
                     |> unwrapResult
                 )
 
@@ -370,7 +387,10 @@ let main argv =
                     TypedTool.define<FcsParseAndCheckArgs>
                         "fcs_check_file"
                         "[FCS in-process] Cache-invalidating parse+typecheck for one file. Use when `workspace_diagnostics` looks stale right after Edit/Write. Surgically drops project-options + project-results entries for THIS project and calls `InvalidateConfiguration` before re-running. Caveat: FCS may still serve from its internal AST cache for transitively-referenced files; fall back to `dotnet build` for ground truth. Mechanics: docs/tools-detailed.md#fcs_check_file."
-                        (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.CheckFile args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.CheckDispatch.run fcsBridge bridge (Dispatcher.CheckFile args))))
                     |> unwrapResult
                 )
 
@@ -430,7 +450,9 @@ let main argv =
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
 
-                            toolResult (runLimited fcsGate (fun () -> fcsBridge.ValidateSnippet args)))
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.CheckDispatch.run fcsBridge bridge (Dispatcher.ValidateSnippet args))))
                     |> unwrapResult
                 )
 
@@ -454,7 +476,10 @@ let main argv =
                     TypedTool.define<FcsProjectSymbolUsesArgs>
                         "fcs_project_symbol_uses"
                         "[FCS in-process] Agent-friendly FCS project-wide symbol-use search by symbol name/full name. Results are cached by resolved project options. Prefer exact=true for narrow queries. Pass projectPath when possible and 'text' for unsaved content."
-                        (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.ProjectSymbolUses args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.ProjectSymbolUses args))))
                     |> unwrapResult
                 )
 
@@ -466,7 +491,9 @@ let main argv =
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
 
-                            toolResult (runLimited fcsGate (fun () -> fcsBridge.FindMemberUsages args)))
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.FindMemberUsages args))))
                     |> unwrapResult
                 )
 
@@ -490,7 +517,9 @@ let main argv =
                             let args =
                                 { args with projectPath = args.projectPath |> Option.orElse bridge.CurrentProjectPath }
 
-                            toolResult (runLimited fcsGate (fun () -> fcsBridge.RecordFieldAudit args)))
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.RecordFieldAudit args))))
                     |> unwrapResult
                 )
 
@@ -498,7 +527,10 @@ let main argv =
                     TypedTool.define<FcsFindSymbolArgs>
                         "fcs_find_symbol"
                         "[FCS in-process] Project-wide symbol search with grouped definitions/references and source-line context in one call. Better than chaining workspace_symbol + fcs_project_symbol_uses + shell reads. Caveat: misses record-field-set sites — use fcs_record_field_audit for those. projectDiagnostics scoped to matched files; errors-only on zero hits. Info/Hint filtered by default (set includeInfo=true). Mechanics: see docs/tools-detailed.md#fcs_find_symbol."
-                        (fun args -> toolResult (runLimited fcsGate (fun () -> fcsBridge.FindSymbol args)))
+                        (fun args ->
+                            toolResult (
+                                runLimited fcsGate (fun () ->
+                                    Dispatcher.FindDispatch.run fcsBridge bridge (Dispatcher.FindSymbol args))))
                     |> unwrapResult
                 )
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Downloads](https://img.shields.io/nuget/dt/FsLangMcp.svg)](https://www.nuget.org/packages/FsLangMcp/)
 [![Target](https://img.shields.io/badge/target-net10.0-blue.svg)](https://dotnet.microsoft.com/)
 
-FsLangMcp is an MCP server for AI coding agents working on F# projects. It combines `fsautocomplete` (LSP-shaped editor semantics) and `FSharp.Compiler.Service` (in-process compiler semantics) into a single stdio process with 32 tools designed for agent workflows. Responses are paginated, errors are returned as structured `invalid_args` envelopes, `fcs_check_file` invalidates stale caches after edits, `fcs_validate_snippet` compiles arbitrary F# against your project's references, and `fcs_record_field_audit` catches the record-construction sites that textual search misses.
+FsLangMcp is an MCP server for AI coding agents working on F# projects. It combines `fsautocomplete` (LSP-shaped editor semantics) and `FSharp.Compiler.Service` (in-process compiler semantics) into a single stdio process designed for agent workflows. Start with **`find`** (one multi-project symbol search) and **`check`** (one trustworthy type-check verdict); the lower-level `textDocument_*` / `workspace_*` / `fcs_*` tools stay available when you need a specific knob. Responses are paginated, errors are returned as structured `invalid_args` envelopes, `fcs_check_file` invalidates stale caches after edits, `fcs_validate_snippet` compiles arbitrary F# against your project's references, and `fcs_record_field_audit` catches the record-construction sites that textual search misses.
 
 See the [Quickstart](#quickstart) for the 60-second on-ramp.
 
@@ -82,6 +82,15 @@ LSP positions (`line`, `character`) are **0-based**.
 
 The `textDocument_*` and `workspace_*` tools are raw LSP/IDE-shaped proxies — useful for exact-position editor operations and FSAC debugging. Prefer the FCS tools and `project_health` for agent-friendly project understanding.
 
+### Primary entry points
+
+Two tools cover the most common agent questions and should be your default. The twelve lower-level "cluster" tools below them are marked _(prefer `find`)_ / _(prefer `check`)_ — reach for them only when you need a specific knob these two don't expose. Full mechanics: [`docs/tools-detailed.md`](docs/tools-detailed.md#find).
+
+| Tool | What it does |
+|------|--------------|
+| `find` | **Recommended for "where is X used?"** Multi-project symbol search — sweeps every member `.fsproj` of the solution and unions definitions, references, record-field set sites, and member-usage sites, recovering cross-project sites the single-project search tools miss. Bare `find(query)` suffices; optional `kind` / `scope` narrow it. Supersedes the seven `find`-cluster tools. |
+| `check` | **Recommended for "did my edit compile?"** One trustworthy `verdict` (`clean` / `errors` / `unknown`) from a FRESH in-process type-check, so it never reports a stale-`{}` false-clean and you don't fall back to `dotnet build`. Bare `check()` suffices; optional `scope` / `path` / `snippet` / `speed`. Supersedes the five `check`-cluster tools. |
+
 ### LSP-proxy tools (FSAC-backed)
 
 All require a prior `set_project`. Tagged `[FSAC]` in tool descriptions.
@@ -89,13 +98,13 @@ All require a prior `set_project`. Tagged `[FSAC]` in tool descriptions.
 | Tool | What it does |
 |------|--------------|
 | `textDocument_completion` | Raw LSP proxy for completion at an exact position. |
-| `textDocument_definition` | Raw LSP proxy for go-to-definition at an exact position. |
-| `textDocument_references` | Raw LSP proxy for find-references at an exact position. For query-based agent workflows prefer `fcs_project_symbol_uses` / `fcs_find_symbol`. |
+| `textDocument_definition` | Raw LSP proxy for go-to-definition at an exact position. _(prefer `find`)_ |
+| `textDocument_references` | Raw LSP proxy for find-references at an exact position. For query-based agent workflows prefer `fcs_project_symbol_uses` / `fcs_find_symbol`. _(prefer `find`)_ |
 | `textDocument_formatting` | Raw LSP formatting proxy via Fantomas. Returns formatted text and edits; does not write to disk. |
 | `textDocument_codeAction` | Raw LSP codeAction proxy at an exact position with empty diagnostic context. Useful for debugging FSAC. |
 | `textDocument_rename` | Raw LSP semantic rename at an exact position. Returns raw `WorkspaceEdit`. |
-| `workspace_symbol` | Quick lookup after `set_project`. IDE-shaped results without source context. |
-| `workspace_diagnostics` | Cached LSP `publishDiagnostics` payload, scoped to one file or to the whole workspace. Optional `path`, `fileGlob`, `severity` filters. |
+| `workspace_symbol` | Quick lookup after `set_project`. IDE-shaped results without source context. _(prefer `find`)_ |
+| `workspace_diagnostics` | Cached LSP `publishDiagnostics` payload, scoped to one file or to the whole workspace. Optional `path`, `fileGlob`, `severity` filters. _(prefer `check`)_ |
 | `fsharp_signature_data` | Structured FSAC signature help via `fsharp/signatureData` at an exact call-site position. |
 
 ### FCS in-process tools (compiler semantics)
@@ -103,30 +112,31 @@ All require a prior `set_project`. Tagged `[FSAC]` in tool descriptions.
 Tagged `[FCS in-process]` in tool descriptions. Most accept an optional `projectPath` that falls back to the active `set_project`.
 
 **Which "check this code" tool should I use?**
-- `fcs_parse_and_check_file` — default. Parse + typecheck one file, returns diagnostics. Cached.
+- `check` — **start here.** One trustworthy `verdict` (`clean` / `errors` / `unknown`) from a FRESH in-process type-check; bare `check()` covers the active project. The four tools below are its lower-level building blocks.
+- `fcs_parse_and_check_file` — parse + typecheck one file, returns diagnostics. Cached.
 - `fcs_check_file` — same as above, but invalidates the project's cached options + results first. Use when `workspace_diagnostics` looks stale right after an Edit/Write.
 - `fsharp_compile` — full project `ParseAndCheckProject`. Slowest but most thorough for project-wide validation. For absolute ground-truth across project boundaries, `dotnet build` is still authoritative.
 
 | Tool | What it does |
 |------|--------------|
-| `fcs_parse_and_check_file` | Parse + typecheck one file. Pass `text` for unsaved content. |
-| `fcs_check_file` | Cache-invalidating parse + typecheck for one file. Surgically drops cached project-options + project-results entries for THIS project and calls `InvalidateConfiguration` before re-running. Use when `workspace_diagnostics` looks stale right after an `Edit` / `Write`. |
+| `fcs_parse_and_check_file` | Parse + typecheck one file. Pass `text` for unsaved content. _(prefer `check`)_ |
+| `fcs_check_file` | Cache-invalidating parse + typecheck for one file. Surgically drops cached project-options + project-results entries for THIS project and calls `InvalidateConfiguration` before re-running. Use when `workspace_diagnostics` looks stale right after an `Edit` / `Write`. _(prefer `check`)_ |
 | `fcs_file_symbols` | Raw FCS symbol extraction for one file. `includeAllUses` adds locals / parameters / usages. Prefer `fcs_file_outline` for normal navigation. |
 | `fcs_file_outline` | Compact per-file outline filtered to definitions: name, kind, range, signature/type, accessibility, declaration range. |
 | `fcs_project_outline` | Compact project-wide outline over filtered compile files. Use `maxFiles` / `maxResultsPerFile` on large projects. |
-| `fcs_project_symbol_uses` | Project-wide symbol-use search by symbol name / full name. Cached by resolved project options. |
-| `fcs_find_symbol` | Project-wide search with grouped definitions / references and source line context. Better than chaining `workspace_symbol` + `fcs_project_symbol_uses` + shell line reads. Misses record-field-set construction sites — for those, use `fcs_record_field_audit`. |
-| `fcs_find_member_usages` | Find all usage sites of a specific `(typeName, memberName)`. FCS-resolved so dotted access, pipeline application, and overload resolution are handled correctly (unlike a textual `rg`). |
-| `fcs_record_field_audit` | Find every construction site for a `(typeName, fieldName)` pair — both `{ Field = expr; ... }` literal form and `{ x with Field = expr }` update form. Closes the gap where `fcs_find_symbol` / `textDocument_references` look up the type name and miss field-set uses. |
+| `fcs_project_symbol_uses` | Project-wide symbol-use search by symbol name / full name. Cached by resolved project options. _(prefer `find`)_ |
+| `fcs_find_symbol` | Project-wide search with grouped definitions / references and source line context. Better than chaining `workspace_symbol` + `fcs_project_symbol_uses` + shell line reads. Misses record-field-set construction sites — for those, use `fcs_record_field_audit`. _(prefer `find`)_ |
+| `fcs_find_member_usages` | Find all usage sites of a specific `(typeName, memberName)`. FCS-resolved so dotted access, pipeline application, and overload resolution are handled correctly (unlike a textual `rg`). _(prefer `find`)_ |
+| `fcs_record_field_audit` | Find every construction site for a `(typeName, fieldName)` pair — both `{ Field = expr; ... }` literal form and `{ x with Field = expr }` update form. Closes the gap where `fcs_find_symbol` / `textDocument_references` look up the type name and miss field-set uses. _(prefer `find`)_ |
 | `fcs_symbol_at_word` | Tolerant FCS symbol lookup by line + word + occurrence. Prefer over exact-position hover/type queries. |
 | `fcs_type_at_position` | Low-level exact-position FCS type/symbol query. Requires `set_project` (or explicit `projectPath` / `projectOptions`). Pass `fuzzy=true` to snap to nearest symbol within ±2 lines / ±5 cols. |
 | `fcs_signature_help` | Exact-position FCS signature help around a call site. |
 | `fcs_make_internal_visible` | Drops the `private` keyword from a `let` / `module` / `type` / `member` / `val` / `new` / `static` / `abstract` / `override` declaration at a given position. Returns a workspace edit; does NOT write the file. |
-| `fcs_validate_snippet` | Compile an arbitrary F# snippet (`.fs` or `.fsi` mode) against the loaded project's references without modifying the project on disk. |
+| `fcs_validate_snippet` | Compile an arbitrary F# snippet (`.fs` or `.fsi` mode) against the loaded project's references without modifying the project on disk. _(prefer `check`)_ |
 | `fcs_referenced_symbols` | Search across the project's *referenced* assemblies (NuGet + framework) for types whose `DisplayName` / `FullName` contains the query (case-insensitive). Reports assembly, kind, accessibility, `isObsolete`. |
 | `fcs_nuget_types` | Enumerate types exported by one referenced assembly, matched by **exact** `SimpleName` (case-insensitive). Does NOT silently fall back to a less-specific assembly. To discover assembly names, use `fcs_referenced_symbols` first. |
 | `fcs_get_project_options` | Get `OtherOptions` for a `.fsproj` via `proj-info`; use the result as `projectOptions` in other FCS tools. |
-| `fsharp_compile` | FCS project validation. Loads `.fsproj` options through `Ionide.ProjInfo`, then runs `FSharpChecker.ParseAndCheckProject`. Does not run `dotnet build`, emit assemblies, or run tests. |
+| `fsharp_compile` | FCS project validation. Loads `.fsproj` options through `Ionide.ProjInfo`, then runs `FSharpChecker.ParseAndCheckProject`. Does not run `dotnet build`, emit assemblies, or run tests. _(prefer `check`)_ |
 | `fsharp_project_inspect` | Read-only `.fsproj` inspection: compile order, references, source summary, and signature/implementation pairing. |
 
 ### Meta / workflow tools
@@ -270,6 +280,8 @@ Then ask for a health report:
 
 Typical next calls:
 
+- `find` with a `query` when you need every use of a symbol across the whole solution (the default "where is X used?" call).
+- `check` for a single `clean` / `errors` / `unknown` verdict after an edit (the default "did it compile?" call).
 - `fcs_parse_and_check_file` with `projectPath` for one file.
 - `fcs_file_outline` for a compact map of a file.
 - `fcs_find_symbol` when you need definitions/references plus source context.

--- a/Types.fs
+++ b/Types.fs
@@ -193,6 +193,69 @@ type FcsFindSymbolArgs =
       /// Opaque cursor from a prior call's `nextCursor`. Omit for the first page.
       cursor: string option }
 
+type FindArgs =
+    { /// Symbol, type, or member name to find. The ONLY required argument.
+      query: string
+      /// Resolution mode: "auto" (default) | "symbol" | "members" | "field" | "definition" | "position".
+      /// auto unions definitions + references + record-field sites + member-usage sites.
+      kind: string option
+      /// Sweep breadth: "auto" (default) | "file" | "project" | "workspace".
+      /// auto/workspace sweep every member project of the active solution.
+      scope: string option
+      /// When true (default), match query exactly; false = case-insensitive substring.
+      exact: bool option
+      /// Restrict the member-usage union to this member name (used with kind=members).
+      ``member``: string option
+      /// Restrict the record-field union to this field name (used with kind=field).
+      field: string option
+      /// File context: derives project options and anchors kind=position / scope=file.
+      path: string option
+      /// 0-based line (LSP convention) for kind=position.
+      line: int option
+      /// Identifier near the position to resolve (kind=position); pairs with line.
+      word: string option
+      /// 0-based occurrence index of `word` on the line. Default -1 (first match).
+      occurrence: int option
+      /// 0-based column (LSP convention) for kind=position.
+      character: int option
+      /// Source-context lines emitted per site. Default 1.
+      contextLines: int option
+      /// Include declaration sites among results. Default true.
+      includeDeclaration: bool option
+      /// Include Info/Hint diagnostics in projectDiagnostics. Default false.
+      includeInfo: bool option
+      /// .fsproj / .sln / .slnx / directory to sweep. Falls back to active set_project.
+      projectPath: string option
+      /// Maximum sites returned per page. Default 500.
+      maxResults: int option
+      /// Opaque cursor from a prior call's nextCursor. Omit for the first page.
+      cursor: string option }
+
+type CheckArgs =
+    { /// What to check: "auto" (default) | "file" | "project" | "workspace" | "snippet".
+      /// auto picks snippet when `snippet` is set, file when `path` is set, else the
+      /// active project (or whole solution when it spans >1 .fsproj).
+      scope: string option
+      /// Single F# file to check. Implies scope=file.
+      path: string option
+      /// Inline F# source to type-check against the project's references. Implies
+      /// scope=snippet. (Consistent rename of fcs_validate_snippet's `content`.)
+      snippet: string option
+      /// scope=workspace fast-mode glob over file URIs (e.g. "src/Adapters/*.fs").
+      fileGlob: string option
+      /// Snippet parse mode: "fs" (default) | "fsi". Pick "fsi" for a signature sketch.
+      mode: string option
+      /// "trusted" (default) runs a FRESH in-process FCS check — the verdict is never
+      /// a stale `{}` false-clean. "fast" reads the cheap cached FSAC snapshot instead.
+      speed: string option
+      /// Minimum severity surfaced in `diagnostics`: "error" (default) | "warning" |
+      /// "information" | "hint" | "all". errorCount/warningCount are unaffected.
+      severity: string option
+      /// .fsproj / .sln / .slnx context. Falls back to active set_project.
+      projectPath: string option
+      /// Timeout in milliseconds for the project/workspace type-check. Default 60000.
+      timeoutMs: int option }
+
 type FcsSymbolAtWordArgs =
     { /// Absolute path to the F# source file containing the word.
       path: string

--- a/docs/tools-detailed.md
+++ b/docs/tools-detailed.md
@@ -1,7 +1,164 @@
 # Detailed Tool Mechanics
 
-This file expands on the five tool descriptions that were compressed in `Program.fs`.
 The MCP description tells you *whether* to call a tool; this file tells you *how it works internally*.
+
+**Start here.** `find` and `check` are the primary entry points and lead every category below.
+`find` is the multi-project symbol sweep that supersedes the seven single-project search tools
+(`fcs_find_symbol`, `fcs_record_field_audit`, `fcs_find_member_usages`, `workspace_symbol`,
+`fcs_project_symbol_uses`, `textDocument_references`, `textDocument_definition`). `check` is the
+single yes/no type-check verdict that supersedes the five lower-level check tools
+(`workspace_diagnostics`, `fsharp_compile`, `fcs_check_file`, `fcs_parse_and_check_file`,
+`fcs_validate_snippet`). Those twelve cluster tools remain registered as lower-level primitives —
+reach for them only when you need a specific knob `find` / `check` don't expose.
+
+---
+
+## find
+
+**Routing description:** `[FCS in-process]` Multi-project symbol search. Sweeps every member
+`.fsproj` of the solution and unions definitions, references, record-field set sites, and
+member-usage sites — recovering cross-project sites that the single-project `fcs_find_symbol` /
+`fcs_record_field_audit` miss. Bare `find(query)` suffices; optional `kind`
+(`auto`|`symbol`|`members`|`field`|`definition`|`position`) and `scope` narrow it. Prefer over
+`fcs_find_symbol` for cross-project refactors.
+
+**Signature:** `query` is the only required argument. `kind` (default `auto`) and `scope` (default
+`auto`) shape the sweep. `exact` (default `true`) toggles exact-vs-substring matching. `member` /
+`field` restrict the member-usage / record-field unions. `path` + `line` + `word` + `occurrence` +
+`character` anchor `kind=position`. `contextLines` (default 1), `includeDeclaration` (default true),
+`includeInfo` (default false), `projectPath` (falls back to active `set_project`), `maxResults`
+(default 500), and `cursor` round out the surface.
+
+### Bare-call default
+
+`find(query)` runs `kind=auto` over `scope=auto` — i.e. it sweeps **every** member project of the
+active solution and unions all four site kinds. No position, no project path, no flags needed; the
+common case is a single argument.
+
+### kind and scope
+
+| `kind` | What it resolves |
+|--------|------------------|
+| `auto` (default) | Union of `symbol` + `members` + `field` definitions/references/sites |
+| `symbol` | Grouped definitions + references (like `fcs_find_symbol`) |
+| `members` | Member-usage sites on a type (like `fcs_find_member_usages`); pair with `member` |
+| `field` | Record construction/update sites (like `fcs_record_field_audit`); pair with `field` |
+| `definition` | Definition sites only (like `textDocument_definition`) |
+| `position` | Exact-position resolution; needs `path` + `line` + `word`/`character` |
+
+| `scope` | Breadth |
+|---------|---------|
+| `auto` (default) / `workspace` | Sweep every member `.fsproj` of the active solution |
+| `project` | The active (or `projectPath`) project only |
+| `file` | The single file at `path` only |
+
+### How it works internally
+
+1. Resolves the sweep target list — every member `.fsproj` of the active solution via
+   `SolutionParsing.listProjects` (or the single active project when `scope=project`/`file`).
+2. For each project, runs FCS name resolution and unions four site kinds: definitions, references,
+   record-field set sites (`{ Field = expr }` and `{ x with Field = expr }`), and member-usage
+   sites — so it covers exactly the ground that `fcs_find_symbol` (no field sites) and
+   `fcs_record_field_audit` (no cross-project sweep) each miss alone.
+3. De-duplicates the union by `(file, range)` and groups by symbol identity.
+4. Falls back to the FSAC `workspace/symbol` index when the FCS sweep returns nothing.
+5. Returns grouped entries with `file`, `range`, `lineText`, plus scoped `projectDiagnostics`.
+
+### The cross-project problem it solves
+
+`fcs_find_symbol` and `fcs_record_field_audit` resolve against **one** project's symbol table, so a
+symbol used in a downstream project is invisible to them. On the consolidation validation fixture,
+the single-project path surfaced **1** site where the whole-solution `find` sweep surfaced **11**.
+`find` removes the "did I check every project?" burden — the bare call already swept all of them.
+
+### Caveats
+
+1. **`matched=false` is a real negative** — it is returned only when both the FCS sweep AND the
+   FSAC index come back empty. A populated `definitions`/`references` group means a hit.
+2. **`exact=true` is the default** — set `exact=false` for case-insensitive substring matching;
+   broad substrings on common names ("Id", "Create") can return large pages.
+3. **`kind=position` needs coordinates** — supply `path` + `line` + (`word` or `character`).
+   0-based LSP coordinates apply.
+
+### Related tools
+
+- `fcs_find_symbol` — single-project grouped definitions/references; `find`'s `kind=symbol` on one project.
+- `fcs_record_field_audit` — single-project record field-set sites; `find`'s `kind=field`.
+- `fcs_find_member_usages` — single-project member-usage sites; `find`'s `kind=members`.
+- `workspace_symbol` / `fcs_project_symbol_uses` / `textDocument_references` / `textDocument_definition`
+  — lower-level single-project primitives `find` unions over.
+
+---
+
+## check
+
+**Routing description:** `[FSAC]` One trustworthy verdict for the active F# context. Bare `check()`
+suffices: returns `verdict` (`clean`|`errors`|`unknown`) after a FRESH in-process type-check, so it
+never reports a stale-`{}` false-clean and you don't fall back to `dotnet build`. Optional `scope`
+(`auto`|`file`|`project`|`workspace`|`snippet`), `path`, `snippet` (inline source), `speed` (trusted
+default | `fast` = cached FSAC snapshot), `severity`. Prefer over `workspace_diagnostics` /
+`fcs_check_file` when you just need a yes/no answer.
+
+**Signature:** every argument is optional. `scope` (default `auto`) picks `snippet` when `snippet`
+is set, `file` when `path` is set, else the active project (or the whole solution when it spans
+>1 `.fsproj`). `path` / `snippet` / `fileGlob` / `mode` (`fs`|`fsi`) target the unit to check.
+`speed` (`trusted` default | `fast`), `severity` (`error` default | `warning` | `information` |
+`hint` | `all`), `projectPath` (falls back to active `set_project`), and `timeoutMs` (default 60000)
+round out the surface.
+
+### Bare-call default
+
+`check()` runs `scope=auto` at `speed=trusted` — a FRESH in-process FCS type-check of the active
+project, collapsed to a single `verdict`. No path, no project, no flags needed for the common
+"did my last edit compile?" question.
+
+### verdict and speed
+
+| `verdict` | Meaning |
+|-----------|---------|
+| `clean` | The checked unit type-checked with zero errors |
+| `errors` | At least one error-severity diagnostic |
+| `unknown` | The check could not run (no project context / resolution failed) — **not** clean |
+
+| `speed` | Behaviour |
+|---------|-----------|
+| `trusted` (default) | Runs a FRESH FCS check; the verdict reflects the current source on disk |
+| `fast` | Reads the cheap cached FSAC `publishDiagnostics` snapshot — may lag a recent edit |
+
+### How it works internally
+
+1. Resolves `scope`: `snippet` when `snippet` is set, `file` when `path` is set, else `project`
+   (escalating to `workspace` when the solution spans more than one `.fsproj`).
+2. At `speed=trusted`, runs a fresh in-process FCS pass (`ParseAndCheckFileInProject` for a file,
+   `ParseAndCheckProject` for a project/workspace) so the result reflects the current source — never
+   a stale cached payload. At `speed=fast`, reads the cached FSAC snapshot instead.
+3. Collapses the diagnostics into one `verdict` (`clean` / `errors` / `unknown`).
+4. Returns `verdict` + `errorCount` + `warningCount` + a `diagnostics` array filtered to `severity`.
+
+### The stale-`{}` problem it solves
+
+Right after an `Edit`/`Write`, `workspace_diagnostics` can serve an empty `{}` from the FSAC cache
+and report **clean** while the file actually has errors — the false-clean that historically drove
+agents to fall back to `dotnet build`. At `speed=trusted`, `check` re-checks fresh in-process, so a
+`clean` verdict is trustworthy and `errors` is caught immediately. One tool, one verdict, no
+build-shell fallback.
+
+### Caveats
+
+1. **`unknown` ≠ `clean`** — `unknown` means the check could not run (no `set_project`, unresolved
+   options). Establish project context and retry; do not treat it as a pass.
+2. **`severity` filters the array only** — `errorCount`/`warningCount` always reflect the full
+   result regardless of the `severity` cutoff applied to the returned `diagnostics`.
+3. **`speed=fast` can lag** — it reads the cached FSAC snapshot; use the default `trusted` when you
+   need the verdict to reflect a just-written edit.
+
+### Related tools
+
+- `workspace_diagnostics` — cached FSAC `publishDiagnostics`; fast but can serve the stale `{}` `check` guards against.
+- `fcs_check_file` — cache-invalidating single-file recheck; `check`'s `scope=file` does this for you.
+- `fsharp_compile` — project-wide `ParseAndCheckProject`; `check`'s `scope=project`.
+- `fcs_parse_and_check_file` — non-invalidating single-file typecheck.
+- `fcs_validate_snippet` — compile an inline snippet; `check`'s `scope=snippet` (`snippet` arg).
 
 ---
 

--- a/tests/FsLangMcp.Tests/CheckTests.fs
+++ b/tests/FsLangMcp.Tests/CheckTests.fs
@@ -1,0 +1,302 @@
+module FsLangMcp.Tests.CheckTests
+
+// ─── #128 Stage 1: the consolidated `check` tool — one trustworthy verdict ───────
+//
+// The five check-cluster tools (workspace_diagnostics, fsharp_compile, fcs_check_file,
+// fcs_parse_and_check_file, fcs_validate_snippet) leave an agent guessing: a `{}` /
+// diagnosticsFileCount:0 from workspace_diagnostics is indistinguishable from "clean"
+// vs "not analyzed yet", so agents fall back to `dotnet build` (#100). `check` collapses
+// that into a single field — `verdict` ∈ { clean, errors, unknown } — backed by a FRESH
+// in-process FCS re-check on the default speed="trusted".
+//
+// Fixture: one leaf project Probe with two source files (Helpers.fs consumed by Main.fs)
+// built ONCE, so cross-file edits exercise the stale-`{}` property. Each test sets the
+// on-disk source it needs first (xUnit serialises methods within a class), so the FCS
+// re-check is what makes the verdict reflect the current revision.
+
+open System
+open System.IO
+open System.Diagnostics
+open System.Text.Json.Nodes
+open System.Threading.Tasks
+open Xunit
+open FsLangMcp.Types
+open FsLangMcp.FcsBridge
+
+// ── Fixture sources ────────────────────────────────────────────────────────────
+
+let private cleanHelpers =
+    String.concat "\n" [ "module Probe.Helpers"; ""; "let add (a: int) (b: int) : int = a + b"; "" ]
+
+// Breaks the contract Main.fs depends on: `add` now returns string, so Main's
+// `let result : int = add 1 2` becomes a CROSS-FILE type error.
+let private brokenHelpers =
+    String.concat "\n" [ "module Probe.Helpers"; ""; "let add (a: int) (b: int) : string = string (a + b)"; "" ]
+
+let private cleanMain =
+    String.concat "\n" [ "module Probe.Main"; ""; "open Probe.Helpers"; ""; "let result: int = add 1 2"; "" ]
+
+// Self-contained single-file type error (string assigned to int).
+let private errorMain =
+    String.concat "\n" [ "module Probe.Main"; ""; "let x: int = \"oops\""; "" ]
+
+let private probeProject =
+    String.concat
+        "\n"
+        [ "<Project Sdk=\"Microsoft.NET.Sdk\">"
+          "  <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>"
+          "  <ItemGroup>"
+          "    <Compile Include=\"Helpers.fs\" />"
+          "    <Compile Include=\"Main.fs\" />"
+          "  </ItemGroup>"
+          "</Project>" ]
+
+// ── Class fixture: written + built ONCE, shared by every test in the class ───────
+
+type CheckFixture() =
+    let runId = Guid.NewGuid().ToString("N")
+    let root = Path.Combine(Path.GetTempPath(), $"fslangmcp_check_{runId}")
+
+    let write (rel: string) (content: string) =
+        let full = Path.Combine(root, rel)
+        Directory.CreateDirectory(Path.GetDirectoryName full) |> ignore
+        File.WriteAllText(full, content)
+        full
+
+    let probeFsproj = write "Probe/Probe.fsproj" probeProject
+    let helpersFs = write "Probe/Helpers.fs" cleanHelpers
+    let mainFs = write "Probe/Main.fs" cleanMain
+
+    // dotnet build once so Ionide.ProjInfo can resolve options (restore + design-time
+    // build). After this, FCS re-checks read source files from disk — no rebuild needed
+    // for the cross-file stale test. Isolation/retry flags mirror FindFixture to survive
+    // the parallel-collection MSBuild contention the find author hit.
+    let buildOnce () =
+        let psi =
+            ProcessStartInfo(
+                "dotnet",
+                $"build \"{probeFsproj}\" -c Debug -m:1 -nologo --disable-build-servers -nodeReuse:false -p:UseSharedCompilation=false"
+            )
+
+        psi.RedirectStandardOutput <- true
+        psi.RedirectStandardError <- true
+        psi.UseShellExecute <- false
+        psi.Environment["MSBUILDDISABLENODEREUSE"] <- "1"
+        psi.Environment["DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER"] <- "1"
+        use p = Process.Start(psi)
+        let stdout = p.StandardOutput.ReadToEnd()
+        let stderr = p.StandardError.ReadToEnd()
+        p.WaitForExit()
+        p.ExitCode, stdout + stderr
+
+    let rec buildWithRetry attempt =
+        let code, log = buildOnce ()
+
+        if code = 0 || attempt >= 3 then
+            code, log
+        else
+            System.Threading.Thread.Sleep(1500)
+            buildWithRetry (attempt + 1)
+
+    let buildExit, buildLog = buildWithRetry 1
+
+    /// Restore the fixture sources to their clean baseline. Called at the top of every
+    /// test so method ordering cannot leak a previous test's on-disk edit.
+    member _.ResetClean() =
+        File.WriteAllText(helpersFs, cleanHelpers)
+        File.WriteAllText(mainFs, cleanMain)
+
+    member _.Root = root
+    member _.ProbeFsproj = probeFsproj
+    member _.HelpersFs = helpersFs
+    member _.MainFs = mainFs
+    member _.BuildExitCode = buildExit
+    member _.BuildLog = buildLog
+
+    interface IDisposable with
+        member _.Dispose() =
+            if Directory.Exists root then
+                try
+                    Directory.Delete(root, true)
+                with _ ->
+                    ()
+
+// ── JSON helpers ─────────────────────────────────────────────────────────────────
+
+let private gi (node: JsonNode) (key: string) = node[key].GetValue<int>()
+let private gb (node: JsonNode) (key: string) = node[key].GetValue<bool>()
+let private gs (node: JsonNode) (key: string) = node[key].GetValue<string>()
+
+// ── Arg builder ──────────────────────────────────────────────────────────────────
+
+let private bareCheck: CheckArgs =
+    { scope = None
+      path = None
+      snippet = None
+      fileGlob = None
+      mode = None
+      speed = None
+      severity = None
+      projectPath = None
+      timeoutMs = None }
+
+// ─────────────────────────────────────────────────────────────────────────────────
+
+type CheckTests(fx: CheckFixture) =
+    interface IClassFixture<CheckFixture>
+
+    [<Fact>]
+    member _.``bare check() on a clean project returns verdict=clean with zero errors``() : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            fx.ResetClean()
+            let bridge = FcsBridge()
+
+            // Bare call: the only thing set is the active-project fall-back Program.fs
+            // injects — every other arg is None.
+            let! result = bridge.Check({ bareCheck with projectPath = Some fx.ProbeFsproj })
+
+            Assert.Equal("succeeded", gs result "status")
+            Assert.Equal("clean", gs result "verdict")
+            Assert.True(gb result "analyzed", "a fresh trusted check must report analyzed=true")
+            Assert.Equal(0, gi result "errorCount")
+            Assert.Equal("project", gs result "scope")
+            Assert.Equal("fcs", gs result "via")
+            Assert.True(gb result "groundTruth", "a clean FCS verdict is ground truth")
+        }
+
+    [<Fact>]
+    member _.``bare check() on a project whose file has a type error returns verdict=errors``() : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            fx.ResetClean()
+            File.WriteAllText(fx.MainFs, errorMain)
+            let bridge = FcsBridge()
+
+            let! result = bridge.Check({ bareCheck with projectPath = Some fx.ProbeFsproj })
+
+            Assert.Equal("errors", gs result "verdict")
+            Assert.True(gi result "errorCount" > 0, "the deliberate type error must be counted")
+
+            // The error itself is surfaced (default severity floor = error).
+            let diagnostics = result["diagnostics"] :?> JsonArray
+            Assert.True(diagnostics.Count > 0, "the error diagnostic must be surfaced")
+        }
+
+    [<Fact>]
+    member _.``check(path=...) on a file with a type error returns verdict=errors``() : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            fx.ResetClean()
+            File.WriteAllText(fx.MainFs, errorMain)
+            let bridge = FcsBridge()
+
+            let! result =
+                bridge.Check(
+                    { bareCheck with
+                        path = Some fx.MainFs
+                        projectPath = Some fx.ProbeFsproj }
+                )
+
+            Assert.Equal("file", gs result "scope")
+            Assert.Equal("errors", gs result "verdict")
+            Assert.True(gi result "errorCount" > 0)
+        }
+
+    [<Fact>]
+    member _.``check(snippet=...) returns errors for a bad snippet and clean for a valid one``() : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            fx.ResetClean()
+            let bridge = FcsBridge()
+
+            let! bad =
+                bridge.Check(
+                    { bareCheck with
+                        snippet = Some "module Probe.SnippetBad\n\nlet x: int = \"oops\"\n"
+                        projectPath = Some fx.ProbeFsproj }
+                )
+
+            Assert.Equal("snippet", gs bad "scope")
+            Assert.Equal("errors", gs bad "verdict")
+            Assert.True(gi bad "errorCount" > 0)
+
+            let! good =
+                bridge.Check(
+                    { bareCheck with
+                        snippet = Some "module Probe.SnippetOk\n\nlet x: int = 42\n"
+                        projectPath = Some fx.ProbeFsproj }
+                )
+
+            Assert.Equal("clean", gs good "verdict")
+            Assert.Equal(0, gi good "errorCount")
+        }
+
+    [<Fact>]
+    member _.``STALE-GUARD: a fresh trusted check after an on-disk cross-file edit never reports a false-clean``
+        ()
+        : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            fx.ResetClean()
+            let bridge = FcsBridge()
+
+            // 1. Pristine revision → clean, freshly analyzed. This populates FCS caches
+            //    with a CLEAN snapshot — exactly the state that would let a stale read
+            //    report a false-clean on the next revision.
+            let! before = bridge.Check({ bareCheck with projectPath = Some fx.ProbeFsproj })
+            Assert.Equal("clean", gs before "verdict")
+            Assert.True(gb before "analyzed", "the baseline check must be a genuine analysis, not a stale read")
+
+            // 2. Break Helpers.fs so Main.fs (a DIFFERENT file) fails to type-check — the
+            //    cross-file shape from #100. No rebuild; only the on-disk source changes.
+            File.WriteAllText(fx.HelpersFs, brokenHelpers)
+
+            // 3. The trusted re-check MUST reflect the new revision, not the cached clean.
+            let! after = bridge.Check({ bareCheck with projectPath = Some fx.ProbeFsproj })
+
+            Assert.Equal("errors", gs after "verdict")
+            Assert.True(gi after "errorCount" > 0, "the cross-file error must be detected on re-check")
+            Assert.True(gb after "analyzed", "the re-check is a fresh analysis")
+            Assert.Equal(Some "fcs-reanalyze", (after["escalated"] |> Option.ofObj |> Option.map (fun n -> n.GetValue<string>())))
+        }
+
+    [<Fact>]
+    member _.``speed=fast on a cold cache reports verdict=unknown, not a false-clean``() : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            fx.ResetClean()
+            let bridge = FcsBridge()
+
+            // No FSAC snapshot is injected (the substrate is called directly), so the
+            // cached snapshot is empty — the stale-`{}` ambiguity. fast must NOT call that
+            // "clean"; it must honestly say "unknown" while the trusted default (other
+            // tests) returns the real verdict.
+            let! result =
+                bridge.Check(
+                    { bareCheck with
+                        projectPath = Some fx.ProbeFsproj
+                        speed = Some "fast" }
+                )
+
+            Assert.Equal("fast", gs result "speed")
+            Assert.Equal("unknown", gs result "verdict")
+            Assert.False(gb result "analyzed", "a cold FSAC cache cannot be a confirmed analysis")
+            Assert.Equal("fsac", gs result "via")
+        }
+
+    [<Fact>]
+    member _.``invalid speed is rejected with invalid_args``() : Task =
+        task {
+            let bridge = FcsBridge()
+
+            let! result =
+                bridge.Check(
+                    { bareCheck with
+                        projectPath = Some fx.ProbeFsproj
+                        speed = Some "turbo" }
+                )
+
+            Assert.Equal("invalid_args", gs result "status")
+            Assert.Contains("speed", gs result "message")
+        }

--- a/tests/FsLangMcp.Tests/FindTests.fs
+++ b/tests/FsLangMcp.Tests/FindTests.fs
@@ -1,0 +1,361 @@
+module FsLangMcp.Tests.FindTests
+
+// ─── #128 Stage 1: the consolidated `find` tool — multi-project union sweep ──────
+//
+// Measures the DELTA between:
+//   (baseline) single-project FcsBridge.FindSymbol / RecordFieldAudit, which run
+//              ParseAndCheckProject on ONE resolved project, and
+//   (new)      FcsBridge.Find (kind=auto, scope=auto), which sweeps every member
+//              .fsproj of the solution, unions GetAllUsesOfAllSymbols() de-duped by
+//              source range, and auto-unions record-field construction/update sites.
+//
+// Fixture (the documented hexagonal port-widening failure shape): a record-of-
+// functions `TraderRole` is DEFINED in Domain and CONSTRUCTED/USED in Stubs + App.
+// Single-project FindSymbol on Domain cannot see the cross-project construction
+// sites; the sweep recovers all of them. Built once per test class (IClassFixture).
+
+open System
+open System.IO
+open System.Diagnostics
+open System.Text
+open System.Text.Json.Nodes
+open System.Threading.Tasks
+open Xunit
+open Xunit.Abstractions
+open FsLangMcp.Types
+open FsLangMcp.FcsBridge
+
+// ── Fixture sources ────────────────────────────────────────────────────────────
+
+let private domainFs =
+    String.concat
+        "\n"
+        [ "namespace Domain"
+          ""
+          "/// Hexagonal port modelled as a record-of-functions."
+          "type TraderRole ="
+          "    { Propose: int -> int -> int }"
+          "" ]
+
+let private stubsFs =
+    String.concat
+        "\n"
+        [ "module Stubs.Roles"
+          ""
+          "open Domain"
+          ""
+          "// S1: record-literal construction site"
+          "let stub: TraderRole = { Propose = fun a b -> a + b }"
+          ""
+          "// S2: record-update construction site"
+          "let stub2: TraderRole = { stub with Propose = fun a b -> a - b }"
+          "" ]
+
+let private appFs =
+    String.concat
+        "\n"
+        [ "module App.Roles"
+          ""
+          "open Domain"
+          ""
+          "// A1: record-literal construction site"
+          "let appRole: TraderRole = { Propose = fun a b -> a * b }"
+          ""
+          "// A2: field-read site"
+          "let computed = appRole.Propose 6 7"
+          ""
+          "// A3: cross-project type-annotation + field-read site"
+          "let useRole (role: TraderRole) = role.Propose 1 2"
+          "" ]
+
+let private leafProject (sourceFile: string) =
+    String.concat
+        "\n"
+        [ "<Project Sdk=\"Microsoft.NET.Sdk\">"
+          "  <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>"
+          $"  <ItemGroup><Compile Include=\"{sourceFile}\" /></ItemGroup>"
+          "</Project>" ]
+
+let private refProject (sourceFile: string) (refRelative: string) =
+    String.concat
+        "\n"
+        [ "<Project Sdk=\"Microsoft.NET.Sdk\">"
+          "  <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>"
+          $"  <ItemGroup><Compile Include=\"{sourceFile}\" /></ItemGroup>"
+          $"  <ItemGroup><ProjectReference Include=\"{refRelative}\" /></ItemGroup>"
+          "</Project>" ]
+
+let private slnx =
+    String.concat
+        "\n"
+        [ "<Solution>"
+          "  <Project Path=\"Domain/Domain.fsproj\" />"
+          "  <Project Path=\"Stubs/Stubs.fsproj\" />"
+          "  <Project Path=\"App/App.fsproj\" />"
+          "</Solution>" ]
+
+// ── Class fixture: written + built ONCE, shared by every test in the class ───────
+
+type FindFixture() =
+    let runId = Guid.NewGuid().ToString("N")
+    let root = Path.Combine(Path.GetTempPath(), $"fslangmcp_find_{runId}")
+
+    let write (rel: string) (content: string) =
+        let full = Path.Combine(root, rel)
+        Directory.CreateDirectory(Path.GetDirectoryName full) |> ignore
+        File.WriteAllText(full, content)
+        full
+
+    let domainFsproj = write "Domain/Domain.fsproj" (leafProject "Domain.fs")
+    let domainSource = write "Domain/Domain.fs" domainFs
+    do write "Stubs/Stubs.fsproj" (refProject "Stubs.fs" "../Domain/Domain.fsproj") |> ignore
+    do write "Stubs/Stubs.fs" stubsFs |> ignore
+    do write "App/App.fsproj" (refProject "App.fs" "../Domain/Domain.fsproj") |> ignore
+    do write "App/App.fs" appFs |> ignore
+    let slnxPath = write "FindSolution.slnx" slnx
+
+    // dotnet build is ground truth and also produces Domain.dll so per-project FCS
+    // sweeps resolve the cross-project TraderRole reference. -m:1 serializes MSBuild
+    // (Stubs + App both P2P-reference Domain → parallel restore races on
+    // Domain.fsproj.nuget.g.props). The whole suite runs xUnit collections in
+    // parallel, so this external build can collide with other tests' in-process
+    // Ionide.ProjInfo MSBuild evaluation — isolate it from the build servers and
+    // retry to keep the gate deterministic.
+    let buildOnce () =
+        let psi =
+            ProcessStartInfo(
+                "dotnet",
+                $"build \"{slnxPath}\" -c Debug -m:1 -nologo --disable-build-servers -nodeReuse:false -p:UseSharedCompilation=false"
+            )
+
+        psi.RedirectStandardOutput <- true
+        psi.RedirectStandardError <- true
+        psi.UseShellExecute <- false
+        psi.Environment["MSBUILDDISABLENODEREUSE"] <- "1"
+        psi.Environment["DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER"] <- "1"
+        use p = Process.Start(psi)
+        let stdout = p.StandardOutput.ReadToEnd()
+        let stderr = p.StandardError.ReadToEnd()
+        p.WaitForExit()
+        p.ExitCode, stdout + stderr
+
+    let rec buildWithRetry attempt =
+        let code, log = buildOnce ()
+
+        if code = 0 || attempt >= 3 then
+            code, log
+        else
+            System.Threading.Thread.Sleep(1500)
+            buildWithRetry (attempt + 1)
+
+    let buildSw = Stopwatch.StartNew()
+    let buildExit, buildLog = buildWithRetry 1
+    do buildSw.Stop()
+
+    member _.Root = root
+    member _.Slnx = slnxPath
+    member _.DomainFsproj = domainFsproj
+    member _.DomainFs = domainSource
+    member _.BuildExitCode = buildExit
+    member _.BuildLog = buildLog
+    member _.BuildMs = int buildSw.ElapsedMilliseconds
+
+    interface IDisposable with
+        member _.Dispose() =
+            if Directory.Exists root then
+                try
+                    Directory.Delete(root, true)
+                with _ ->
+                    ()
+
+// ── JSON helpers ─────────────────────────────────────────────────────────────────
+
+let private gi (node: JsonNode) (key: string) = node[key].GetValue<int>()
+let private gb (node: JsonNode) (key: string) = node[key].GetValue<bool>()
+let private gs (node: JsonNode) (key: string) = node[key].GetValue<string>()
+
+let private sumReferenceCounts (result: JsonNode) =
+    match result["symbols"] with
+    | :? JsonArray as arr -> arr |> Seq.sumBy (fun s -> s["referenceCount"].GetValue<int>())
+    | _ -> 0
+
+// ── Arg builders ────────────────────────────────────────────────────────────────
+
+let private findArgs (projectPath: string) (query: string) : FindArgs =
+    { query = query
+      kind = None
+      scope = None
+      exact = None
+      ``member`` = None
+      field = None
+      path = None
+      line = None
+      word = None
+      occurrence = None
+      character = None
+      contextLines = Some 0
+      includeDeclaration = None
+      includeInfo = None
+      projectPath = Some projectPath
+      maxResults = Some 500
+      cursor = None }
+
+let private findSymbolArgs (domainFs: string) (domainFsproj: string) (query: string) (exact: bool) : FcsFindSymbolArgs =
+    { path = domainFs
+      text = None
+      projectPath = Some domainFsproj
+      projectOptions = None
+      symbolQuery = query
+      exact = Some exact
+      maxResults = Some 200
+      contextLines = Some 0
+      includeDeclaration = Some true
+      includeInfo = None
+      cursor = None }
+
+// ─────────────────────────────────────────────────────────────────────────────────
+
+type FindTests(fx: FindFixture, output: ITestOutputHelper) =
+    interface IClassFixture<FindFixture>
+
+    [<Fact>]
+    member _.``DELTA: bare find sweeps all member projects and recovers cross-project field-set sites the single-project tools miss``
+        ()
+        : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+
+            let bridge = FcsBridge()
+
+            // ── BASELINE 1: single-project FindSymbol on Domain (exact) ──────────
+            let! baseExact = bridge.FindSymbol(findSymbolArgs fx.DomainFs fx.DomainFsproj "TraderRole" true)
+            let baseExactUses = gi baseExact "matchedUseCount"
+            let baseExactRefs = sumReferenceCounts baseExact
+
+            // ── BASELINE 2: single-project RecordFieldAudit on Domain ────────────
+            let! baseAudit =
+                bridge.RecordFieldAudit(
+                    { typeName = "TraderRole"
+                      fieldName = "Propose"
+                      path = None
+                      text = None
+                      projectPath = Some fx.DomainFsproj
+                      projectOptions = None
+                      maxResults = Some 200
+                      cursor = None }
+                )
+
+            let baseAuditMatched = gi baseAudit "matchedCount"
+
+            // ── NEW: bare find (kind=auto, scope=auto, exact=default true) ───────
+            let! find = bridge.Find(findArgs fx.Slnx "TraderRole")
+
+            Assert.Equal("succeeded", gs find "status")
+            let resolution = find["resolution"]
+            let breakdown = find["breakdown"]
+            let totalSites = gi find "totalSites"
+            let projectsSwept = gi find "projectsSwept"
+
+            let fLit = gi breakdown "fieldSetLiteral"
+            let fUpd = gi breakdown "fieldSetUpdate"
+            let fRead = gi breakdown "fieldRead"
+            let fieldSitesTotal = fLit + fUpd + fRead
+
+            // ── Render the delta table to test output ────────────────────────────
+            // Precompute every value: F# forbids "double-quoted" lookups inside an
+            // interpolation hole of a $"..." string.
+            let bDefs = gi breakdown "definitions"
+            let bRefs = gi breakdown "references"
+            let bMem = gi breakdown "memberUsages"
+            let rMatched = gb resolution "matched"
+            let rVia = gs resolution "via"
+            let rSwept = gi resolution "projectsSwept"
+            let rFcs = gi resolution "fcsSiteCount"
+            let sweepMs = gi find "sweepElapsedMs"
+
+            let line (s: string) = output.WriteLine(s)
+            line "# FsLangMCP #128 — `find` measured delta (synthetic 3-project fixture)"
+            line ""
+            line "Fixture: TraderRole defined in Domain; constructed/used in Stubs + App."
+            line "| Path                              | Query      | Sites | Cross-project field sites |"
+            line "|-----------------------------------|------------|-------|---------------------------|"
+            line $"| OLD FindSymbol (Domain only)      | exact=true | uses={baseExactUses}, refs={baseExactRefs} | MISSED (0) |"
+            line $"| OLD RecordFieldAudit (Domain)     | Propose    | matched={baseAuditMatched} | MISSED (0) |"
+            line $"| NEW find (Domain+Stubs+App)       | auto       | totalSites={totalSites} | field sites={fieldSitesTotal} |"
+            line ""
+            line $"find breakdown: definitions={bDefs}, references={bRefs}, fieldSetLiteral={fLit}, fieldSetUpdate={fUpd}, fieldRead={fRead}, memberUsages={bMem}"
+            line $"resolution: matched={rMatched}, via={rVia}, projectsSwept={rSwept}, fcsSiteCount={rFcs}"
+            line $"sweepElapsedMs={sweepMs} (fixture build {fx.BuildMs}ms)"
+
+            // ── Assertions: the improvement must be unambiguous ──────────────────
+            // 1. Baselines see ZERO cross-project field construction sites.
+            Assert.Equal(0, baseAuditMatched)
+            Assert.Equal(0, baseExactRefs)
+
+            // 2. The sweep covers all three member projects.
+            Assert.Equal(3, projectsSwept)
+
+            // 3. matched=true, resolved via the FCS multi-project sweep.
+            Assert.True(gb resolution "matched", "find must report matched=true for a present symbol")
+            Assert.Equal("fcs-multiproject-sweep", gs resolution "via")
+
+            // 4. The sweep recovers all 5 record-field sites (2 literal + 1 update + 2 read).
+            Assert.Equal(2, fLit)
+            Assert.Equal(1, fUpd)
+            Assert.Equal(2, fRead)
+
+            // 5. Field sites are surfaced in the grouped `fieldSites` bucket too.
+            let fieldBucket = find["fieldSites"] :?> JsonArray
+            Assert.Equal(5, fieldBucket.Count)
+
+            // 6. Headline: find finds strictly more than the single-project baseline.
+            Assert.True(
+                totalSites > baseExactUses + baseExactRefs,
+                $"Expected find ({totalSites}) > single-project baseline ({baseExactUses + baseExactRefs})"
+            )
+        }
+
+    [<Fact>]
+    member _.``find with kind=field unions only the cross-project record-field sites``() : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            let bridge = FcsBridge()
+
+            let! find = bridge.Find({ findArgs fx.Slnx "TraderRole" with kind = Some "field" })
+
+            Assert.Equal("succeeded", gs find "status")
+            let breakdown = find["breakdown"]
+            // field-only: no definitions / references, all 5 field sites present.
+            Assert.Equal(0, gi breakdown "definitions")
+            Assert.Equal(0, gi breakdown "references")
+            Assert.Equal(5, gi breakdown "fieldSetLiteral" + gi breakdown "fieldSetUpdate" + gi breakdown "fieldRead")
+            Assert.Equal("field", gs find "kindResolved")
+        }
+
+    [<Fact>]
+    member _.``find with empty query returns invalid_args naming query``() : Task =
+        task {
+            let bridge = FcsBridge()
+            let! result = bridge.Find(findArgs fx.Slnx "   ")
+
+            Assert.Equal("invalid_args", gs result "status")
+            Assert.Contains("query", gs result "message")
+        }
+
+    [<Fact>]
+    member _.``find reports matched=false ONLY when the symbol is truly absent everywhere``() : Task =
+        task {
+            Assert.True((fx.BuildExitCode = 0), $"Fixture build failed (exit {fx.BuildExitCode}):\n{fx.BuildLog}")
+            let bridge = FcsBridge()
+
+            // A name that exists in NO member project. No fsacProbe is injected here,
+            // so this exercises the FCS-empty branch directly: matched must be false.
+            let! find = bridge.Find(findArgs fx.Slnx "ZzzNoSuchSymbol_4827")
+
+            Assert.Equal("succeeded", gs find "status")
+            Assert.Equal(0, gi find "totalSites")
+            let resolution = find["resolution"]
+            Assert.False(gb resolution "matched", "absent symbol must report matched=false")
+            Assert.Equal("none", gs resolution "via")
+            Assert.Equal(3, gi resolution "projectsSwept")
+        }

--- a/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
+++ b/tests/FsLangMcp.Tests/FsLangMcp.Tests.fsproj
@@ -24,6 +24,8 @@
     <Compile Include="OutlineE2ETests.fs" />
     <Compile Include="SymbolPaginationTests.fs" />
     <Compile Include="ToolDescriptionSchemaTests.fs" />
+    <Compile Include="FindTests.fs" />
+    <Compile Include="CheckTests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Implements **Stage 0 + Stage 1** of the tool-surface consolidation epic (#128): two intent-named tools, `find` and `check`, that hide the FCS/FSAC backend seam and directly attack the agent **rg-fallback** documented across #100 (surface sprawl: 34 tools, ~6k-token routing tax, 22 overlapping-intent pairs).

## What's in this PR

**Stage 0 — dispatcher seam (`refactor`, byte-identical).** The 12 "cluster" handlers route through a new `Dispatcher.fs` (`FindRequest`/`CheckRequest`) instead of calling FcsBridge/LspBridge directly. Concurrency gating + projectPath fallback stay in Program.fs adapters. Proven byte-identical by the existing suite staying green.

**Stage 1 — `find` + `check` (`feat`, additive).**
- **`find(query)`** — multi-project symbol sweep. Unions definitions, references, record-field set sites, and member-usage sites across every member `.fsproj`, recovering cross-project sites single-project `fcs_find_symbol`/`fcs_record_field_audit` structurally miss. **Validated by spike + test: 1→11 sites, 0→5 cross-project** on the fixture reproducing the `TraderRole.Propose` widening that drove agents to `rg`. `matched=false` only when the FCS sweep **and** FSAC index are both empty (no confident cross-project false-negative). Cost: `projectCacheSize` 3→50 + background pre-warm in `set_project`.
- **`check()`** — one trustworthy `verdict` (`clean|errors|unknown`) after a **fresh** in-process type-check; fixes the stale-`{}` false-clean that drove `dotnet build` fallbacks. `speed:"fast"` opts into the cached snapshot; never silently shells out to a build.

**Additive + steered.** The 12 cluster tools are unchanged but their descriptions now steer to `find`/`check`; docs (`tools-detailed.md`, `README`, `AGENT_INTEGRATION.md`) lead with them. Removal of the legacy tools is **telemetry-gated/future**, per the design — not in this PR.

## Verification
- `dotnet restore` — NuGet audit clean.
- `dotnet build -c Release` — 0 warnings (warnings-as-errors).
- **314/314 tests** (303 prior + 4 find + 7 check), confirmed independently.
- `audit-tool-descriptions.py` — green; every description ≤500 chars (largest cluster 497).
- **E2E smoke on the built 0.10.0 binary — 8/8:** 36 tools, `find("FindArgs")` → 30 sites via `fcs-multiproject-sweep`, `find("")` → invalid_args, `check()` → `verdict:clean`.

## Not in scope (deliberate)
Backend-prefix (`[FCS]`/`[FSAC]`) stripping and legacy-tool removal are deferred — they're cross-cutting and telemetry-gated. An A/B protocol (rg-fallback rate, wrong-tool-call rate, tokens-to-first-correct-tool) over the #100 corpus is documented in #128 to measure the win before removing the old tools.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
